### PR TITLE
fix: correct gateway protocol values and string IDs

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -135,10 +135,10 @@ describe('GatewayClient', () => {
       expect(connectMsg.params.minProtocol).toBe(3);
       expect(connectMsg.params.maxProtocol).toBe(3);
       expect(connectMsg.params.client).toEqual({
-        id: 'session-viewer',
+        id: 'gateway-client',
         version: '0.1.0',
-        platform: 'browser',
-        mode: 'frontend',
+        platform: 'linux',
+        mode: 'backend',
       });
       expect(connectMsg.params.role).toBe('operator');
       expect(connectMsg.params.scopes).toEqual(['operator.admin']);

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -22,9 +22,9 @@ export class GatewayClient {
   private ws: WebSocket | null = null;
   private options: Required<GatewayClientOptions>;
   private requestId = 0;
-  private connectRequestId: number | null = null;
+  private connectRequestId: string | null = null;
   private pendingRequests = new Map<
-    number,
+    string,
     { resolve: (value: unknown) => void; reject: (reason: Error) => void }
   >();
   private eventHandlers: EventHandler[] = [];
@@ -86,7 +86,7 @@ export class GatewayClient {
         return;
       }
 
-      const id = ++this.requestId;
+      const id = String(++this.requestId);
       const message: JsonRpcRequest = {
         type: 'req',
         method,
@@ -173,7 +173,7 @@ export class GatewayClient {
     if (msg.type === 'event') {
       if (msg.event === 'connect.challenge') {
         // Send connect request with auth
-        const id = ++this.requestId;
+        const id = String(++this.requestId);
         this.connectRequestId = id;
         const connectReq: JsonRpcRequest = {
           type: 'req',
@@ -183,10 +183,10 @@ export class GatewayClient {
             minProtocol: 3,
             maxProtocol: 3,
             client: {
-              id: 'session-viewer',
+              id: 'gateway-client',
               version: '0.1.0',
-              platform: 'browser',
-              mode: 'frontend',
+              platform: 'linux',
+              mode: 'backend',
             },
             auth: { token: this.options.token },
             role: 'operator',

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -4,12 +4,12 @@ export interface JsonRpcRequest {
   type: 'req';
   method: string;
   params?: Record<string, unknown>;
-  id: number;
+  id: string;
 }
 
 export interface JsonRpcResponse {
   type: 'res';
-  id: number;
+  id: string;
   ok: boolean;
   result?: unknown;
   error?: { message: string };


### PR DESCRIPTION
Fixes #7

## Root causes (two bugs)
1. `client.id: 'session-viewer'` and `client.mode: 'frontend'` not in Gateway allowlist
2. `id` field was `number` but Gateway schema requires `NonEmptyString`

## Changes
- `client.id` → `'gateway-client'`
- `client.mode` → `'backend'`
- `client.platform` → `'linux'`
- Request `id` type → `string` (types.ts + client.ts)
- Tests updated with correct values

## E2E Verification
```
✅ AUTH OK
✅ Sessions count: 0
```
Tested against real Gateway at `ws://127.0.0.1:18789/ws`