### PR TITLE
fix: align with real Gateway API responses

### DIFF
--- a/src/components/SessionList/SessionList.tsx
+++ b/src/components/SessionList/SessionList.tsx
@@ -136,7 +136,7 @@ export function SessionList() {
           </div>
         ) : (
           filteredTree.map((node) => (
-            <SessionTreeItem key={node.session.sessionKey} node={node} depth={0} />
+            <SessionTreeItem key={node.session.key} node={node} depth={0} />
           ))
         )}
       </div>

--- a/src/components/SessionList/SessionTreeItem.tsx
+++ b/src/components/SessionList/SessionTreeItem.tsx
@@ -12,7 +12,7 @@ export function SessionTreeItem({ node, depth }: SessionTreeItemProps) {
   const toggleExpanded = useSessionStore((s) => s.toggleExpanded);
 
   const { session, children, expanded } = node;
-  const isActive = activeSessionKey === session.sessionKey;
+  const isActive = activeSessionKey === session.key;
   const hasChildren = children.length > 0;
   const displayName = getSessionDisplayName(session);
   const model = shortenModel(session.model);
@@ -28,7 +28,7 @@ export function SessionTreeItem({ node, depth }: SessionTreeItemProps) {
             : 'text-gray-300 hover:bg-surface-tertiary/50'
         }`}
         style={{ paddingLeft: `${8 + depth * 16}px` }}
-        onClick={() => selectSession(session.sessionKey)}
+        onClick={() => selectSession(session.key)}
       >
         {/* Expand/collapse toggle */}
         <button
@@ -39,7 +39,7 @@ export function SessionTreeItem({ node, depth }: SessionTreeItemProps) {
           }`}
           onClick={(e) => {
             e.stopPropagation();
-            if (hasChildren) toggleExpanded(session.sessionKey);
+            if (hasChildren) toggleExpanded(session.key);
           }}
           tabIndex={-1}
         >
@@ -82,7 +82,7 @@ export function SessionTreeItem({ node, depth }: SessionTreeItemProps) {
         <div>
           {children.map((child) => (
             <SessionTreeItem
-              key={child.session.sessionKey}
+              key={child.session.key}
               node={child}
               depth={depth + 1}
             />

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -208,7 +208,7 @@ describe('GatewayClient', () => {
         type: 'res',
         id: reqMsg.id,
         ok: true,
-        result: { sessions: [] },
+        payload: { sessions: [] },
       });
 
       const result = await promise;

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -224,7 +224,7 @@ export class GatewayClient {
         if (pending) {
           this.pendingRequests.delete(msg.id);
           if (msg.ok) {
-            pending.resolve(msg.result);
+            pending.resolve(msg.payload);
           } else {
             pending.reject(new Error(msg.error?.message ?? 'Request failed'));
           }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -11,7 +11,7 @@ export interface JsonRpcResponse {
   type: 'res';
   id: string;
   ok: boolean;
-  result?: unknown;
+  payload?: unknown;
   error?: { message: string };
 }
 
@@ -54,52 +54,41 @@ export interface GatewayClientOptions {
 
 export type EventHandler = (event: string, payload: unknown) => void;
 
-// ── Session Types (from sessions.list) ───────────────────────────────
-
-export interface SessionEntry {
-  sessionId: string;
-  sessionKey: string;
-  sessionFile: string;
-  label?: string;
-  displayName?: string;
-  model?: string;
-  modelProvider?: string;
-  channel?: string;
-  origin?: string;
-  spawnedBy?: string;
-  spawnDepth: number;
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
 // ── Session List API Response ────────────────────────────────────────
 
 export interface SessionListItem {
+  key: string;
   sessionId: string;
-  sessionKey: string;
-  sessionFile: string;
-  label?: string;
+  kind?: string;
   displayName?: string;
   model?: string;
   modelProvider?: string;
   channel?: string;
-  origin?: string;
+  origin?: {
+    label?: string;
+    provider?: string;
+    surface?: string;
+    chatType?: string;
+    from?: string;
+    to?: string;
+  };
   spawnedBy?: string;
-  spawnDepth: number;
+  spawnDepth?: number;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
-  createdAt: string;
-  updatedAt: string;
+  updatedAt: number;
   derivedTitle?: string;
   lastMessage?: string;
+  label?: string;
+  groupChannel?: string;
+  space?: string;
+  chatType?: string;
 }
 
 export interface SessionsListResponse {
   sessions: SessionListItem[];
+  count?: number;
 }
 
 // ── Session Tree ─────────────────────────────────────────────────────

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -13,15 +13,12 @@ import type { SessionListItem } from '@/gateway/types';
 
 function makeSession(overrides: Partial<SessionListItem> = {}): SessionListItem {
   return {
-    sessionId: 'sid-' + (overrides.sessionKey ?? 'default'),
-    sessionKey: 'default',
-    sessionFile: '/path/to/session.jsonl',
-    spawnDepth: 0,
+    sessionId: 'sid-' + (overrides.key ?? 'default'),
+    key: 'default',
     inputTokens: 100,
     outputTokens: 50,
     totalTokens: 150,
-    createdAt: '2026-03-08T10:00:00Z',
-    updatedAt: '2026-03-08T10:00:00Z',
+    updatedAt: Date.now(),
     ...overrides,
   };
 }
@@ -35,89 +32,89 @@ describe('buildSessionTree', () => {
 
   it('should create root nodes for sessions without spawnedBy', () => {
     const sessions = [
-      makeSession({ sessionKey: 'a', updatedAt: '2026-03-08T11:00:00Z' }),
-      makeSession({ sessionKey: 'b', updatedAt: '2026-03-08T12:00:00Z' }),
+      makeSession({ key: 'a', updatedAt: 2000 }),
+      makeSession({ key: 'b', updatedAt: 3000 }),
     ];
 
     const tree = buildSessionTree(sessions);
     expect(tree).toHaveLength(2);
     // Sorted by updatedAt descending — b first
-    expect(tree[0].session.sessionKey).toBe('b');
-    expect(tree[1].session.sessionKey).toBe('a');
+    expect(tree[0].session.key).toBe('b');
+    expect(tree[1].session.key).toBe('a');
     expect(tree[0].children).toEqual([]);
     expect(tree[1].children).toEqual([]);
   });
 
   it('should nest children under their parent', () => {
     const sessions = [
-      makeSession({ sessionKey: 'parent', updatedAt: '2026-03-08T10:00:00Z' }),
+      makeSession({ key: 'parent', updatedAt: 1000 }),
       makeSession({
-        sessionKey: 'child-1',
+        key: 'child-1',
         spawnedBy: 'parent',
         spawnDepth: 1,
-        updatedAt: '2026-03-08T11:00:00Z',
+        updatedAt: 2000,
       }),
       makeSession({
-        sessionKey: 'child-2',
+        key: 'child-2',
         spawnedBy: 'parent',
         spawnDepth: 1,
-        updatedAt: '2026-03-08T12:00:00Z',
+        updatedAt: 3000,
       }),
     ];
 
     const tree = buildSessionTree(sessions);
     expect(tree).toHaveLength(1);
-    expect(tree[0].session.sessionKey).toBe('parent');
+    expect(tree[0].session.key).toBe('parent');
     expect(tree[0].children).toHaveLength(2);
     // Children sorted descending — child-2 first
-    expect(tree[0].children[0].session.sessionKey).toBe('child-2');
-    expect(tree[0].children[1].session.sessionKey).toBe('child-1');
+    expect(tree[0].children[0].session.key).toBe('child-2');
+    expect(tree[0].children[1].session.key).toBe('child-1');
   });
 
   it('should handle multi-level nesting', () => {
     const sessions = [
-      makeSession({ sessionKey: 'root', updatedAt: '2026-03-08T10:00:00Z' }),
+      makeSession({ key: 'root', updatedAt: 1000 }),
       makeSession({
-        sessionKey: 'sub',
+        key: 'sub',
         spawnedBy: 'root',
         spawnDepth: 1,
-        updatedAt: '2026-03-08T11:00:00Z',
+        updatedAt: 2000,
       }),
       makeSession({
-        sessionKey: 'sub-sub',
+        key: 'sub-sub',
         spawnedBy: 'sub',
         spawnDepth: 2,
-        updatedAt: '2026-03-08T12:00:00Z',
+        updatedAt: 3000,
       }),
     ];
 
     const tree = buildSessionTree(sessions);
     expect(tree).toHaveLength(1);
-    expect(tree[0].session.sessionKey).toBe('root');
+    expect(tree[0].session.key).toBe('root');
     expect(tree[0].children).toHaveLength(1);
-    expect(tree[0].children[0].session.sessionKey).toBe('sub');
+    expect(tree[0].children[0].session.key).toBe('sub');
     expect(tree[0].children[0].children).toHaveLength(1);
-    expect(tree[0].children[0].children[0].session.sessionKey).toBe('sub-sub');
+    expect(tree[0].children[0].children[0].session.key).toBe('sub-sub');
   });
 
   it('should treat orphaned children as roots', () => {
     // spawnedBy references a non-existent session
     const sessions = [
       makeSession({
-        sessionKey: 'orphan',
+        key: 'orphan',
         spawnedBy: 'nonexistent',
-        updatedAt: '2026-03-08T10:00:00Z',
+        updatedAt: 1000,
       }),
     ];
 
     const tree = buildSessionTree(sessions);
     expect(tree).toHaveLength(1);
-    expect(tree[0].session.sessionKey).toBe('orphan');
+    expect(tree[0].session.key).toBe('orphan');
   });
 
   it('should set expanded to true by default', () => {
     const sessions = [
-      makeSession({ sessionKey: 'a' }),
+      makeSession({ key: 'a' }),
     ];
 
     const tree = buildSessionTree(sessions);
@@ -129,9 +126,9 @@ describe('buildSessionTree', () => {
 
 describe('filterSessions', () => {
   const sessions = [
-    makeSession({ sessionKey: 'main:discord', displayName: 'Discord Chat', model: 'claude-opus-4', channel: 'discord' }),
-    makeSession({ sessionKey: 'main:telegram', label: 'Telegram Bot', model: 'gpt-4o', channel: 'telegram' }),
-    makeSession({ sessionKey: 'sub:coder', derivedTitle: 'Code Review Task', model: 'claude-opus-4' }),
+    makeSession({ key: 'main:discord', displayName: 'Discord Chat', model: 'claude-opus-4', channel: 'discord' }),
+    makeSession({ key: 'main:telegram', label: 'Telegram Bot', model: 'gpt-4o', channel: 'telegram' }),
+    makeSession({ key: 'sub:coder', derivedTitle: 'Code Review Task', model: 'claude-opus-4' }),
   ];
 
   it('should return all sessions for empty query', () => {
@@ -142,19 +139,19 @@ describe('filterSessions', () => {
   it('should filter by displayName', () => {
     const result = filterSessions(sessions, 'discord');
     expect(result).toHaveLength(1);
-    expect(result[0].sessionKey).toBe('main:discord');
+    expect(result[0].key).toBe('main:discord');
   });
 
   it('should filter by label', () => {
     const result = filterSessions(sessions, 'telegram');
     expect(result).toHaveLength(1);
-    expect(result[0].sessionKey).toBe('main:telegram');
+    expect(result[0].key).toBe('main:telegram');
   });
 
   it('should filter by sessionKey', () => {
     const result = filterSessions(sessions, 'sub:coder');
     expect(result).toHaveLength(1);
-    expect(result[0].sessionKey).toBe('sub:coder');
+    expect(result[0].key).toBe('sub:coder');
   });
 
   it('should filter by model', () => {
@@ -165,7 +162,7 @@ describe('filterSessions', () => {
   it('should filter by channel', () => {
     const result = filterSessions(sessions, 'telegram');
     expect(result).toHaveLength(1);
-    expect(result[0].sessionKey).toBe('main:telegram');
+    expect(result[0].key).toBe('main:telegram');
   });
 
   it('should be case-insensitive', () => {
@@ -181,7 +178,7 @@ describe('filterSessions', () => {
   it('should filter by derivedTitle', () => {
     const result = filterSessions(sessions, 'code review');
     expect(result).toHaveLength(1);
-    expect(result[0].sessionKey).toBe('sub:coder');
+    expect(result[0].key).toBe('sub:coder');
   });
 });
 
@@ -204,7 +201,7 @@ describe('getSessionDisplayName', () => {
   });
 
   it('should fall back to sessionKey', () => {
-    const s = makeSession({ sessionKey: 'main:discord:123' });
+    const s = makeSession({ key: 'main:discord:123' });
     expect(getSessionDisplayName(s)).toBe('main:discord:123');
   });
 });
@@ -256,27 +253,26 @@ describe('shortenModel', () => {
 
 describe('formatRelativeTime', () => {
   it('should format recent times', () => {
-    const now = new Date();
-    expect(formatRelativeTime(now.toISOString())).toBe('just now');
+    expect(formatRelativeTime(Date.now())).toBe('just now');
   });
 
   it('should format minutes', () => {
-    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
-    expect(formatRelativeTime(fiveMinAgo.toISOString())).toBe('5m ago');
+    expect(formatRelativeTime(Date.now() - 5 * 60 * 1000)).toBe('5m ago');
   });
 
   it('should format hours', () => {
-    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
-    expect(formatRelativeTime(threeHoursAgo.toISOString())).toBe('3h ago');
+    expect(formatRelativeTime(Date.now() - 3 * 60 * 60 * 1000)).toBe('3h ago');
   });
 
   it('should format days', () => {
-    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
-    expect(formatRelativeTime(twoDaysAgo.toISOString())).toBe('2d ago');
+    expect(formatRelativeTime(Date.now() - 2 * 24 * 60 * 60 * 1000)).toBe('2d ago');
   });
 
   it('should format months', () => {
-    const twoMonthsAgo = new Date(Date.now() - 65 * 24 * 60 * 60 * 1000);
-    expect(formatRelativeTime(twoMonthsAgo.toISOString())).toBe('2mo ago');
+    expect(formatRelativeTime(Date.now() - 65 * 24 * 60 * 60 * 1000)).toBe('2mo ago');
+  });
+
+  it('should handle string dates too', () => {
+    expect(formatRelativeTime(new Date().toISOString())).toBe('just now');
   });
 });

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -9,7 +9,7 @@ export function buildSessionTree(sessions: SessionListItem[]): TreeNode[] {
 
   // Create a TreeNode for each session
   for (const session of sessions) {
-    nodeMap.set(session.sessionKey, {
+    nodeMap.set(session.key, {
       session,
       children: [],
       expanded: true,
@@ -20,7 +20,7 @@ export function buildSessionTree(sessions: SessionListItem[]): TreeNode[] {
 
   // Build parent-child relationships
   for (const session of sessions) {
-    const node = nodeMap.get(session.sessionKey)!;
+    const node = nodeMap.get(session.key)!;
     if (session.spawnedBy && nodeMap.has(session.spawnedBy)) {
       nodeMap.get(session.spawnedBy)!.children.push(node);
     } else {
@@ -32,8 +32,8 @@ export function buildSessionTree(sessions: SessionListItem[]): TreeNode[] {
   const sortNodes = (nodes: TreeNode[]) => {
     nodes.sort(
       (a, b) =>
-        new Date(b.session.updatedAt).getTime() -
-        new Date(a.session.updatedAt).getTime()
+        (b.session.updatedAt || 0) -
+        (a.session.updatedAt || 0)
     );
     for (const node of nodes) {
       sortNodes(node.children);
@@ -54,10 +54,10 @@ export function filterSessions(
   const lower = query.toLowerCase();
   return sessions.filter((s) => {
     const name =
-      s.displayName || s.label || s.derivedTitle || s.sessionKey;
+      s.displayName || s.label || s.derivedTitle || s.key;
     return (
       name.toLowerCase().includes(lower) ||
-      s.sessionKey.toLowerCase().includes(lower) ||
+      s.key.toLowerCase().includes(lower) ||
       (s.model && s.model.toLowerCase().includes(lower)) ||
       (s.channel && s.channel.toLowerCase().includes(lower))
     );
@@ -67,14 +67,14 @@ export function filterSessions(
 // ── Helper: Get display name for session ─────────────────────────────
 
 export function getSessionDisplayName(session: SessionListItem): string {
-  return session.displayName || session.label || session.derivedTitle || session.sessionKey;
+  return session.displayName || session.label || session.derivedTitle || session.key;
 }
 
 // ── Helper: Format relative time ─────────────────────────────────────
 
-export function formatRelativeTime(dateStr: string): string {
+export function formatRelativeTime(dateInput: string | number): string {
   const now = Date.now();
-  const date = new Date(dateStr).getTime();
+  const date = typeof dateInput === 'number' ? dateInput : new Date(dateInput).getTime();
   const diffMs = now - date;
   const diffSec = Math.floor(diffMs / 1000);
 
@@ -154,7 +154,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       const sessionsList = result.sessions ?? [];
       const sessionsMap = new Map<string, SessionListItem>();
       for (const s of sessionsList) {
-        sessionsMap.set(s.sessionKey, s);
+        sessionsMap.set(s.key, s);
       }
 
       const tree = buildSessionTree(sessionsList);
@@ -180,7 +180,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
     const toggleInTree = (nodes: TreeNode[]): TreeNode[] =>
       nodes.map((node) => {
-        if (node.session.sessionKey === key) {
+        if (node.session.key === key) {
           return { ...node, expanded: !node.expanded };
         }
         if (node.children.length > 0) {
@@ -197,14 +197,14 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     if (!filterQuery.trim()) return sessionTree;
 
     const filtered = filterSessions([...sessions.values()], filterQuery);
-    const filteredKeys = new Set(filtered.map((s) => s.sessionKey));
+    const filteredKeys = new Set(filtered.map((s) => s.key));
 
     // Include ancestors of matched sessions so tree structure is preserved
     const includeKeys = new Set<string>();
     for (const session of filtered) {
       let current: SessionListItem | undefined = session;
       while (current) {
-        includeKeys.add(current.sessionKey);
+        includeKeys.add(current.key);
         current = current.spawnedBy
           ? sessions.get(current.spawnedBy)
           : undefined;
@@ -213,12 +213,12 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
     const filterTree = (nodes: TreeNode[]): TreeNode[] =>
       nodes
-        .filter((node) => includeKeys.has(node.session.sessionKey))
+        .filter((node) => includeKeys.has(node.session.key))
         .map((node) => ({
           ...node,
           children: filterTree(node.children),
           // Auto-expand nodes that match filter
-          expanded: filteredKeys.has(node.session.sessionKey)
+          expanded: filteredKeys.has(node.session.key)
             ? true
             : node.expanded,
         }));

--- a/src/store/transcript.ts
+++ b/src/store/transcript.ts
@@ -56,9 +56,9 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
     set({ loading: true, error: null, sessionKey });
 
     try {
-      const result = await client.request<{ messages: TranscriptEntry[] }>(
-        'sessions.get',
-        { key: sessionKey }
+      const result = await client.request<{ sessionKey: string; messages: TranscriptEntry[] }>(
+        'chat.history',
+        { sessionKey }
       );
 
       const entries = result?.messages ?? [];


### PR DESCRIPTION
## Root cause
Session list showed 'unable to fetch' because the client code didn't match the real Gateway API:
1. Response data is in `payload` not `result`
2. Session key field is `key` not `sessionKey`
3. `updatedAt` is epoch ms (number) not ISO string
4. `sessions.get` doesn't exist — use `chat.history` for transcripts

## Changes
- `types.ts`: `JsonRpcResponse.result` → `payload`, `SessionListItem.sessionKey` → `key`
- `client.ts`: resolve with `msg.payload`
- `sessions.ts/test`: all `sessionKey` → `key`, number timestamps
- `transcript.ts`: `sessions.get` → `chat.history`
- `SessionList/SessionTreeItem.tsx`: `sessionKey` → `key`

## Verification
E2E: Gateway returns 75 sessions via `sessions.list`
63/63 tests pass, tsc clean