### PR TITLE
refactor: round-based fishbone layout with tool-call bones

### DIFF
--- a/src/components/Detail/DetailPanel.tsx
+++ b/src/components/Detail/DetailPanel.tsx
@@ -1,72 +1,21 @@
 // ── DetailPanel — Selected node detail view ──────────────────────────
 //
-// Main container for the detail panel displayed at the bottom of the
-// graph area. Shows full content of the selected transcript entry:
-//   - MessageView for message entries
-//   - ToolCallView for tool calls in structured content
-//   - MetadataView for entry metadata
-//   - Summary display for compaction / branch_summary
+// When a round node is selected, shows the full round content:
+//   - User prompt (MessageView)
+//   - Tool calls (collapsible list)
+//   - Final assistant response (MessageView)
+//   - Metadata (total tokens, timestamp, round type)
+//
+// When a bone node is selected, shows the single tool call detail.
 
 import { useMemo } from 'react';
 import type { TranscriptEntry, ContentBlock } from '@/gateway/types';
+import type { Round } from '@/layout/types';
 import { useTranscriptStore } from '@/store/transcript';
 import { MessageView } from './MessageView';
 import { ToolCallView } from './ToolCallView';
 import { MetadataView } from './MetadataView';
-
-// ── Helper: build a map of tool_use_id → tool_result content ────────
-
-function buildToolResultsMap(
-  entries: TranscriptEntry[],
-  selectedEntry: TranscriptEntry
-): Map<string, string> {
-  const map = new Map<string, string>();
-
-  // Collect tool_use ids from the selected entry
-  const content = selectedEntry.message?.content;
-  if (!Array.isArray(content)) return map;
-
-  const toolUseIds = new Set<string>();
-  for (const block of content) {
-    if (block.type === 'tool_use' && block.id) {
-      toolUseIds.add(block.id as string);
-    }
-  }
-
-  if (toolUseIds.size === 0) return map;
-
-  // Search forward for tool_result entries that reference these ids
-  const selectedIdx = entries.findIndex((e) => e.id === selectedEntry.id);
-  if (selectedIdx < 0) return map;
-
-  for (let i = selectedIdx + 1; i < entries.length && map.size < toolUseIds.size; i++) {
-    const e = entries[i];
-    if (e.message?.role === 'tool' || e.type === 'message') {
-      const c = e.message?.content;
-      // Check if this is a tool_result block referencing one of our tool_use ids
-      if (Array.isArray(c)) {
-        for (const block of c) {
-          const toolUseId = block.tool_use_id as string | undefined;
-          if (toolUseId && toolUseIds.has(toolUseId)) {
-            const text = typeof block.content === 'string'
-              ? block.content
-              : block.text ?? JSON.stringify(block.content ?? block, null, 2);
-            map.set(toolUseId, text);
-          }
-        }
-      } else if (typeof c === 'string') {
-        // Some tool results are plain strings with tool_use_id on the entry itself
-        const data = e.data as Record<string, unknown> | undefined;
-        const toolUseId = data?.tool_use_id as string | undefined;
-        if (toolUseId && toolUseIds.has(toolUseId)) {
-          map.set(toolUseId, c);
-        }
-      }
-    }
-  }
-
-  return map;
-}
+import { formatTokenCount } from './MetadataView';
 
 // ── Placeholder when nothing is selected ─────────────────────────────
 
@@ -81,21 +30,141 @@ function EmptyState() {
   );
 }
 
-// ── Summary view for compaction / branch_summary ─────────────────────
+// ── Round detail view ────────────────────────────────────────────────
 
-function SummaryView({ entry }: { entry: TranscriptEntry }) {
-  const label = entry.type === 'compaction' ? 'Compaction Summary' : 'Branch Summary';
+const ROUND_TYPE_LABELS: Record<string, { bg: string; text: string; label: string }> = {
+  normal:    { bg: 'bg-blue-500/20',   text: 'text-blue-300',   label: 'Conversation' },
+  tool_call: { bg: 'bg-orange-500/20', text: 'text-orange-300', label: 'Tool Call' },
+  subagent:  { bg: 'bg-purple-500/20', text: 'text-purple-300', label: 'Subagent' },
+};
+
+function RoundDetail({ round }: { round: Round }) {
+  const typeStyle = ROUND_TYPE_LABELS[round.type] ?? ROUND_TYPE_LABELS.normal;
+
+  // Build tool results map from the round's raw entries
+  const toolResults = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const tc of round.toolCalls) {
+      if (tc.id && tc.resultContent) {
+        map.set(tc.id, tc.resultContent);
+      }
+    }
+    return map;
+  }, [round.toolCalls]);
+
+  // Collect all tool_use content blocks from all assistant messages in the round
+  const allToolUseBlocks = useMemo(() => {
+    const blocks: ContentBlock[] = [];
+    for (const entry of round.rawEntries) {
+      if (entry.message?.role === 'assistant' && Array.isArray(entry.message.content)) {
+        for (const block of entry.message.content) {
+          if (block.type === 'tool_use') {
+            blocks.push(block as ContentBlock);
+          }
+        }
+      }
+    }
+    return blocks;
+  }, [round.rawEntries]);
+
   return (
-    <div className="px-3 py-2">
-      <div className="flex items-center gap-2 mb-2">
-        <span className="text-[10px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-wider bg-yellow-500/20 text-yellow-300">
-          {label}
-        </span>
+    <>
+      {/* Round header */}
+      <div className="px-3 py-2 border-b border-surface-tertiary">
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-[10px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-wider ${typeStyle.bg} ${typeStyle.text}`}
+          >
+            {typeStyle.label}
+          </span>
+          <span className="text-[10px] text-gray-600 font-mono">{round.id}</span>
+          {round.totalTokens > 0 && (
+            <span className="text-[10px] text-gray-500 font-mono ml-auto">
+              {formatTokenCount(round.totalTokens)} tokens
+            </span>
+          )}
+        </div>
+        {round.subagentSpawns.length > 0 && (
+          <div className="mt-1 text-[10px] text-purple-400">
+            🧬 Spawned {round.subagentSpawns.length} subagent{round.subagentSpawns.length > 1 ? 's' : ''}
+          </div>
+        )}
       </div>
-      <p className="text-xs text-gray-300 leading-relaxed whitespace-pre-wrap">
-        {entry.summary ?? 'No summary available.'}
-      </p>
-    </div>
+
+      {/* User prompt */}
+      {round.userMessage?.message && (
+        <MessageView
+          message={round.userMessage.message}
+          timestamp={round.userMessage.timestamp}
+        />
+      )}
+
+      {/* Tool calls */}
+      {allToolUseBlocks.length > 0 && (
+        <ToolCallView contentBlocks={allToolUseBlocks} toolResults={toolResults} />
+      )}
+
+      {/* Final assistant response */}
+      {round.assistantMessage?.message &&
+        round.assistantMessage !== round.userMessage && (
+          <MessageView
+            message={round.assistantMessage.message}
+            timestamp={round.assistantMessage.timestamp}
+          />
+        )}
+
+      {/* Round metadata */}
+      <div className="px-3 py-2 border-t border-surface-tertiary">
+        <h4 className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+          Round Metadata
+        </h4>
+        <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-0.5 text-xs">
+          <span className="text-gray-500">Type</span>
+          <span className="text-gray-300 font-mono">{round.type}</span>
+          <span className="text-gray-500">Timestamp</span>
+          <span className="text-gray-300 font-mono">
+            {round.timestamp ? new Date(round.timestamp).toLocaleString() : '—'}
+          </span>
+          <span className="text-gray-500">Total tokens</span>
+          <span className="text-gray-300 font-mono">{formatTokenCount(round.totalTokens)}</span>
+          <span className="text-gray-500">Messages</span>
+          <span className="text-gray-300 font-mono">{round.rawEntries.length}</span>
+          <span className="text-gray-500">Tool calls</span>
+          <span className="text-gray-300 font-mono">{round.toolCalls.length}</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Bone (tool call) detail view ─────────────────────────────────────
+
+function BoneDetail({ roundId, boneIndex, rounds }: { roundId: string; boneIndex: number; rounds: Round[] }) {
+  const round = rounds.find((r) => r.id === roundId);
+  if (!round) return <EmptyState />;
+
+  const tc = round.toolCalls[boneIndex];
+  if (!tc) return <EmptyState />;
+
+  // Build a synthetic content block for ToolCallView
+  const blocks: ContentBlock[] = [tc.toolUseBlock as ContentBlock];
+  const toolResults = new Map<string, string>();
+  if (tc.id && tc.resultContent) {
+    toolResults.set(tc.id, tc.resultContent);
+  }
+
+  return (
+    <>
+      <div className="px-3 py-2 border-b border-surface-tertiary">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-wider bg-orange-500/20 text-orange-300">
+            Tool Call
+          </span>
+          <span className="text-xs font-mono text-gray-300">{tc.name}</span>
+        </div>
+      </div>
+      <ToolCallView contentBlocks={blocks} toolResults={toolResults} />
+    </>
   );
 }
 
@@ -103,21 +172,32 @@ function SummaryView({ entry }: { entry: TranscriptEntry }) {
 
 export function DetailPanel() {
   const selectedNodeId = useTranscriptStore((s) => s.selectedNodeId);
-  const entries = useTranscriptStore((s) => s.entries);
+  const rounds = useTranscriptStore((s) => s.rounds);
 
-  // Find the selected entry
-  const selectedEntry = useMemo(
-    () => (selectedNodeId ? entries.find((e) => e.id === selectedNodeId) : undefined),
-    [selectedNodeId, entries]
-  );
+  // Determine what we're showing
+  const detail = useMemo(() => {
+    if (!selectedNodeId) return null;
 
-  // Build tool results map
-  const toolResults = useMemo(
-    () => (selectedEntry ? buildToolResultsMap(entries, selectedEntry) : new Map<string, string>()),
-    [entries, selectedEntry]
-  );
+    // Check if it's a bone node: "{roundId}-bone-{index}"
+    const boneMatch = selectedNodeId.match(/^(round-\d+)-bone-(\d+)$/);
+    if (boneMatch) {
+      return {
+        kind: 'bone' as const,
+        roundId: boneMatch[1],
+        boneIndex: parseInt(boneMatch[2], 10),
+      };
+    }
 
-  if (!selectedEntry) {
+    // Check if it's a round node
+    const round = rounds.find((r) => r.id === selectedNodeId);
+    if (round) {
+      return { kind: 'round' as const, round };
+    }
+
+    return null;
+  }, [selectedNodeId, rounds]);
+
+  if (!detail) {
     return (
       <div className="h-full bg-surface-secondary border-t border-surface-tertiary">
         <EmptyState />
@@ -125,25 +205,16 @@ export function DetailPanel() {
     );
   }
 
-  const hasMessage = selectedEntry.type === 'message' && selectedEntry.message;
-  const hasSummary =
-    (selectedEntry.type === 'compaction' || selectedEntry.type === 'branch_summary') &&
-    selectedEntry.summary;
-  const contentBlocks: ContentBlock[] = Array.isArray(selectedEntry.message?.content)
-    ? (selectedEntry.message!.content as ContentBlock[])
-    : [];
-  const hasToolCalls = contentBlocks.some((b) => b.type === 'tool_use');
-
   return (
     <div className="h-full bg-surface-secondary border-t border-surface-tertiary flex flex-col overflow-hidden">
-      {/* Drag handle / header */}
+      {/* Header */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-surface-tertiary bg-surface-secondary shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
             Detail
           </span>
           <span className="text-[10px] text-gray-600 font-mono truncate max-w-[200px]">
-            {selectedEntry.id}
+            {selectedNodeId}
           </span>
         </div>
         <button
@@ -159,42 +230,10 @@ export function DetailPanel() {
 
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto">
-        {/* Message content */}
-        {hasMessage && (
-          <MessageView
-            message={selectedEntry.message!}
-            timestamp={selectedEntry.timestamp}
-          />
+        {detail.kind === 'round' && <RoundDetail round={detail.round} />}
+        {detail.kind === 'bone' && (
+          <BoneDetail roundId={detail.roundId} boneIndex={detail.boneIndex} rounds={rounds} />
         )}
-
-        {/* Summary content (compaction / branch) */}
-        {hasSummary && <SummaryView entry={selectedEntry} />}
-
-        {/* Non-message, non-summary entries */}
-        {!hasMessage && !hasSummary && (
-          <div className="px-3 py-2">
-            <div className="flex items-center gap-2 mb-2">
-              <span className="text-[10px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-wider bg-gray-500/20 text-gray-300">
-                {selectedEntry.type}
-              </span>
-            </div>
-            {selectedEntry.data != null && (
-              <pre className="text-[11px] text-gray-300 font-mono whitespace-pre-wrap break-all max-h-40 overflow-y-auto bg-surface/50 rounded p-2">
-                {typeof selectedEntry.data === 'string'
-                  ? selectedEntry.data
-                  : JSON.stringify(selectedEntry.data, null, 2)}
-              </pre>
-            )}
-          </div>
-        )}
-
-        {/* Tool calls */}
-        {hasToolCalls && (
-          <ToolCallView contentBlocks={contentBlocks} toolResults={toolResults} />
-        )}
-
-        {/* Metadata */}
-        <MetadataView entry={selectedEntry} />
       </div>
     </div>
   );

--- a/src/components/Graph/SessionNode.tsx
+++ b/src/components/Graph/SessionNode.tsx
@@ -1,40 +1,75 @@
 // ── SessionNode — Custom React Flow node ─────────────────────────────
 //
-// Renders a single transcript entry as a fishbone node:
+// Renders either:
+//   A) A round node  – shows round summary, tool-call badge, toggle button
+//   B) A bone node   – small tool-call indicator when a round is expanded
+//
+// Visual encoding:
 //   - Size ∝ token count
-//   - Color encodes entry category
-//   - Shows role icon + truncated preview + token badge
-//   - Handles: left (target) + right (source)
+//   - Colour encodes round type (blue=normal, orange=tool_call, purple=subagent)
+//   - Handles: left (target) + right (source) + bottom (source, for bones)
 
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { SessionNodeData } from '@/layout/fishbone';
+import { useTranscriptStore } from '@/store/transcript';
 
-const ROLE_ICONS: Record<string, string> = {
-  user:      '👤',
-  assistant: '🤖',
-  system:    '⚙️',
-  tool:      '🔧',
-  session:   '▶️',
-  compaction: '📦',
-  model_change: '🔄',
-  branch_summary: '🌿',
-};
+// ── Bone node (small tool-call indicator) ────────────────────────────
 
-function getRoleIcon(data: SessionNodeData): string {
-  if (data.type === 'message' && data.role) {
-    return ROLE_ICONS[data.role] ?? '💬';
-  }
-  return ROLE_ICONS[data.type] ?? '📋';
+function BoneNode({ data, selected }: { data: SessionNodeData; selected: boolean }) {
+  return (
+    <div
+      style={{
+        width: data.nodeWidth,
+        height: data.nodeHeight,
+        borderColor: data.color,
+      }}
+      className={`
+        relative rounded border bg-surface-secondary px-2 py-1
+        flex items-center gap-1.5 overflow-hidden
+        cursor-pointer transition-shadow text-xs
+        ${selected ? 'shadow-lg ring-2 ring-accent' : 'hover:shadow-md'}
+      `}
+    >
+      <span className="text-[10px]">🔧</span>
+      <span className="text-[11px] text-gray-300 truncate font-mono">
+        {data.toolName}
+      </span>
+
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!w-2 !h-2 !bg-gray-500 !border-gray-600"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!w-2 !h-2 !bg-gray-500 !border-gray-600"
+      />
+    </div>
+  );
 }
 
-function SessionNodeComponent({ data, selected }: NodeProps) {
-  const nodeData = data as unknown as SessionNodeData;
-  const { nodeWidth, nodeHeight, color, preview, totalTokens } = nodeData;
-  const icon = getRoleIcon(nodeData);
+// ── Round node (main spine node) ─────────────────────────────────────
+
+function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolean }) {
+  const toggleRound = useTranscriptStore((s) => s.toggleRound);
+
+  const handleToggle = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      toggleRound(data.entryId);
+    },
+    [toggleRound, data.entryId]
+  );
+
+  const { nodeWidth, nodeHeight, color, preview, totalTokens, toolCallCount, expanded, hasSubagent } = data;
 
   // Opacity increases with token count (min 0.6, max 1.0)
-  const opacity = Math.min(1.0, 0.6 + (totalTokens > 0 ? Math.min(0.4, totalTokens / 10000) : 0));
+  const opacity = Math.min(
+    1.0,
+    0.6 + (totalTokens > 0 ? Math.min(0.4, totalTokens / 10000) : 0)
+  );
 
   return (
     <div
@@ -50,18 +85,46 @@ function SessionNodeComponent({ data, selected }: NodeProps) {
         cursor-pointer transition-shadow
         ${selected ? 'shadow-lg ring-2 ring-accent' : 'hover:shadow-md'}
       `}
+      title={
+        data.userPreview
+          ? `User: ${data.userPreview}\n\nAssistant: ${data.assistantPreview}`
+          : data.assistantPreview || undefined
+      }
     >
-      {/* Top: role icon + preview */}
+      {/* Top row: preview text */}
       <div className="flex items-start gap-1 min-w-0">
-        <span className="text-sm flex-shrink-0">{icon}</span>
+        <span className="text-sm flex-shrink-0">
+          {hasSubagent ? '🧬' : toolCallCount > 0 ? '🤖' : '💬'}
+        </span>
         <span className="text-[11px] text-gray-300 truncate leading-tight">
           {preview || '…'}
         </span>
       </div>
 
-      {/* Bottom: token badge */}
-      {totalTokens > 0 && (
-        <div className="flex justify-end">
+      {/* Bottom row: badges */}
+      <div className="flex items-center justify-between">
+        {/* Tool call badge + toggle */}
+        <div className="flex items-center gap-1">
+          {toolCallCount > 0 && (
+            <button
+              onClick={handleToggle}
+              className="text-[9px] px-1 py-0.5 rounded-sm font-mono flex items-center gap-0.5 hover:bg-surface-tertiary transition-colors"
+              style={{ color }}
+              title={expanded ? 'Collapse tool calls' : 'Expand tool calls'}
+            >
+              <span className="text-[8px]">{expanded ? '▼' : '▶'}</span>
+              🔧×{toolCallCount}
+            </button>
+          )}
+          {hasSubagent && (
+            <span className="text-[9px] px-1 py-0.5 rounded-sm" style={{ color: '#a855f7' }}>
+              🧬 sub
+            </span>
+          )}
+        </div>
+
+        {/* Token badge */}
+        {totalTokens > 0 && (
           <span
             className="text-[9px] px-1 py-0.5 rounded-sm font-mono"
             style={{ backgroundColor: `${color}30`, color }}
@@ -71,8 +134,8 @@ function SessionNodeComponent({ data, selected }: NodeProps) {
               : totalTokens}{' '}
             tok
           </span>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Handles */}
       <Handle
@@ -85,8 +148,27 @@ function SessionNodeComponent({ data, selected }: NodeProps) {
         position={Position.Right}
         className="!w-2 !h-2 !bg-gray-500 !border-gray-600"
       />
+      {/* Bottom handle for bone connections */}
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        className="!w-2 !h-2 !bg-gray-500 !border-gray-600"
+      />
     </div>
   );
+}
+
+// ── SessionNode dispatcher ───────────────────────────────────────────
+
+function SessionNodeComponent({ data, selected }: NodeProps) {
+  const nodeData = data as unknown as SessionNodeData;
+
+  if (nodeData.isBone) {
+    return <BoneNode data={nodeData} selected={!!selected} />;
+  }
+
+  return <RoundNode data={nodeData} selected={!!selected} />;
 }
 
 export const SessionNode = memo(SessionNodeComponent);

--- a/src/layout/fishbone.test.ts
+++ b/src/layout/fishbone.test.ts
@@ -1,63 +1,83 @@
-// ── Fishbone layout tests ────────────────────────────────────────────
+// ── Fishbone layout tests (Round-based) ──────────────────────────────
 
 import { describe, it, expect } from 'vitest';
 import { computeFishboneLayout } from './fishbone';
 import { computeNodeSize, BASE_SIZE, SCALE_FACTOR } from './node-sizing';
-import type { TranscriptEntry } from '@/gateway/types';
+import type { Round } from './types';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function makeEntry(
-  id: string,
-  parentId: string | undefined,
-  type: TranscriptEntry['type'] = 'message',
-  overrides: Partial<TranscriptEntry> = {}
-): TranscriptEntry {
+function makeRound(
+  index: number,
+  overrides: Partial<Round> = {}
+): Round {
   return {
-    id,
-    parentId,
-    type,
+    id: `round-${index}`,
+    toolCalls: [],
+    subagentSpawns: [],
+    rawEntries: [],
+    totalTokens: 150,
     timestamp: new Date().toISOString(),
-    message:
-      type === 'message'
-        ? {
-            role: 'assistant',
-            content: `Message ${id}`,
-            usage: { input_tokens: 100, output_tokens: 50 },
-          }
-        : undefined,
+    type: 'normal',
     ...overrides,
   };
 }
 
+function makeToolCallRound(
+  index: number,
+  toolNames: string[],
+  overrides: Partial<Round> = {}
+): Round {
+  return makeRound(index, {
+    type: 'tool_call',
+    toolCalls: toolNames.map((name, i) => ({
+      id: `tc-${index}-${i}`,
+      name,
+      toolUseBlock: { type: 'tool_use', name, id: `tc-${index}-${i}` },
+      resultContent: `Result of ${name}`,
+    })),
+    ...overrides,
+  });
+}
+
+function makeSubagentRound(
+  index: number,
+  overrides: Partial<Round> = {}
+): Round {
+  return makeRound(index, {
+    type: 'subagent',
+    subagentSpawns: ['subagent-session-1'],
+    toolCalls: [{
+      id: `tc-${index}-0`,
+      name: 'subagents',
+      toolUseBlock: { type: 'tool_use', name: 'subagents', id: `tc-${index}-0` },
+    }],
+    ...overrides,
+  });
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
-describe('computeFishboneLayout', () => {
+describe('computeFishboneLayout (Round-based)', () => {
   it('returns empty nodes and edges for empty input', () => {
     const result = computeFishboneLayout([]);
     expect(result.nodes).toEqual([]);
     expect(result.edges).toEqual([]);
   });
 
-  it('lays out a single entry', () => {
-    const entries = [makeEntry('a', undefined)];
-    const result = computeFishboneLayout(entries);
+  it('lays out a single round', () => {
+    const rounds = [makeRound(0)];
+    const result = computeFishboneLayout(rounds);
 
     expect(result.nodes).toHaveLength(1);
     expect(result.edges).toHaveLength(0);
-    expect(result.nodes[0].id).toBe('a');
+    expect(result.nodes[0].id).toBe('round-0');
     expect(result.nodes[0].position.y).toBe(0); // main spine
   });
 
-  it('lays out a linear conversation left-to-right', () => {
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'b'),
-      makeEntry('d', 'c'),
-    ];
-
-    const result = computeFishboneLayout(entries);
+  it('lays out multiple rounds left-to-right on spine', () => {
+    const rounds = [makeRound(0), makeRound(1), makeRound(2), makeRound(3)];
+    const result = computeFishboneLayout(rounds);
 
     expect(result.nodes).toHaveLength(4);
     expect(result.edges).toHaveLength(3);
@@ -74,357 +94,169 @@ describe('computeFishboneLayout', () => {
     }
 
     // Edges connect sequentially
-    expect(result.edges[0].source).toBe('a');
-    expect(result.edges[0].target).toBe('b');
-    expect(result.edges[1].source).toBe('b');
-    expect(result.edges[1].target).toBe('c');
-    expect(result.edges[2].source).toBe('c');
-    expect(result.edges[2].target).toBe('d');
+    expect(result.edges[0].source).toBe('round-0');
+    expect(result.edges[0].target).toBe('round-1');
+    expect(result.edges[1].source).toBe('round-1');
+    expect(result.edges[1].target).toBe('round-2');
+    expect(result.edges[2].source).toBe('round-2');
+    expect(result.edges[2].target).toBe('round-3');
   });
 
-  it('handles branching (multiple children from one node)', () => {
-    // a → b → c  (main spine)
-    //   → d → e  (branch from a)
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'b'),
-      makeEntry('d', 'a'), // second child of a → branch
-      makeEntry('e', 'd'),
+  it('does not show tool call bones when not expanded', () => {
+    const rounds = [
+      makeToolCallRound(0, ['exec', 'read', 'write']),
     ];
+    const result = computeFishboneLayout(rounds, new Set());
 
-    const result = computeFishboneLayout(entries);
+    // Only the round node, no bones
+    expect(result.nodes).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
 
-    expect(result.nodes).toHaveLength(5);
+    // Node data should show tool call count
+    const data = result.nodes[0].data as Record<string, unknown>;
+    expect(data.toolCallCount).toBe(3);
+    expect(data.expanded).toBe(false);
+  });
 
-    // Main spine nodes at y=0
-    const mainNodes = result.nodes.filter((n) => ['a', 'b', 'c'].includes(n.id));
-    for (const node of mainNodes) {
-      expect(node.position.y).toBe(0);
+  it('shows tool call bones when round is expanded', () => {
+    const rounds = [
+      makeToolCallRound(0, ['exec', 'read', 'write']),
+    ];
+    const expanded = new Set(['round-0']);
+    const result = computeFishboneLayout(rounds, expanded);
+
+    // 1 round node + 3 bone nodes
+    expect(result.nodes).toHaveLength(4);
+
+    // 3 edges: round→bone0, bone0→bone1, bone1→bone2
+    expect(result.edges).toHaveLength(3);
+
+    // Bone nodes should be below the round node (positive Y)
+    const roundNode = result.nodes.find((n) => n.id === 'round-0')!;
+    const boneNodes = result.nodes.filter((n) => n.id.includes('bone'));
+    expect(boneNodes).toHaveLength(3);
+    for (const bone of boneNodes) {
+      expect(bone.position.y).toBeGreaterThan(roundNode.position.y);
     }
 
-    // Branch nodes should be offset from y=0
-    const branchNode = result.nodes.find((n) => n.id === 'd');
-    expect(branchNode).toBeDefined();
-    expect(branchNode!.position.y).not.toBe(0);
-
-    // There should be an edge from a to d
-    const branchEdge = result.edges.find(
-      (e) => e.source === 'a' && e.target === 'd'
-    );
-    expect(branchEdge).toBeDefined();
-
-    // And from d to e
-    const innerEdge = result.edges.find(
-      (e) => e.source === 'd' && e.target === 'e'
-    );
-    expect(innerEdge).toBeDefined();
+    // Check bone node data
+    const bone0 = result.nodes.find((n) => n.id === 'round-0-bone-0')!;
+    expect((bone0.data as Record<string, unknown>).toolName).toBe('exec');
+    expect((bone0.data as Record<string, unknown>).isBone).toBe(true);
   });
 
-  it('alternates branch direction for multiple branches', () => {
-    // a → b (main)
-    //   → c (branch 1)
-    //   → d (branch 2)
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'a'),
-      makeEntry('d', 'a'),
+  it('assigns correct round type data', () => {
+    const rounds = [
+      makeRound(0),                             // normal
+      makeToolCallRound(1, ['exec']),            // tool_call
+      makeSubagentRound(2),                      // subagent
     ];
 
-    const result = computeFishboneLayout(entries);
-
-    const nodeC = result.nodes.find((n) => n.id === 'c');
-    const nodeD = result.nodes.find((n) => n.id === 'd');
-
-    expect(nodeC).toBeDefined();
-    expect(nodeD).toBeDefined();
-
-    // They should be on opposite sides of the spine
-    // (one positive Y, one negative Y)
-    expect(nodeC!.position.y * nodeD!.position.y).toBeLessThan(0);
-  });
-
-  it('assigns correct node types', () => {
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a', 'message'),
-      makeEntry('c', 'b', 'compaction', {
-        summary: 'Compacted conversation',
-        tokensBefore: 50000,
-        message: undefined,
-      }),
-    ];
-
-    const result = computeFishboneLayout(entries);
+    const result = computeFishboneLayout(rounds);
 
     expect(result.nodes).toHaveLength(3);
 
-    // All should be sessionNode type
-    for (const node of result.nodes) {
-      expect(node.type).toBe('sessionNode');
-    }
+    const normalNode = result.nodes.find((n) => n.id === 'round-0')!;
+    expect((normalNode.data as Record<string, unknown>).roundType).toBe('normal');
 
-    // Check data categories
-    const sessionNode = result.nodes.find((n) => n.id === 'a');
-    expect((sessionNode!.data as Record<string, unknown>).category).toBe('system');
+    const toolNode = result.nodes.find((n) => n.id === 'round-1')!;
+    expect((toolNode.data as Record<string, unknown>).roundType).toBe('tool_call');
 
-    const messageNode = result.nodes.find((n) => n.id === 'b');
-    expect((messageNode!.data as Record<string, unknown>).category).toBe('conversation');
-
-    const compactionNode = result.nodes.find((n) => n.id === 'c');
-    expect((compactionNode!.data as Record<string, unknown>).category).toBe('system');
+    const subNode = result.nodes.find((n) => n.id === 'round-2')!;
+    expect((subNode.data as Record<string, unknown>).roundType).toBe('subagent');
+    expect((subNode.data as Record<string, unknown>).hasSubagent).toBe(true);
   });
 
-  it('collects nested sub-branches instead of discarding them', () => {
-    // Spine: a → b → c
-    // Branch from b: d → e
-    // Sub-branch from d: f → g  (nested branch off a branch)
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'b'),
-      makeEntry('d', 'b'), // branch from b
-      makeEntry('e', 'd'),
-      makeEntry('f', 'd'), // sub-branch from d (second child)
-      makeEntry('g', 'f'),
+  it('uses correct colours for round types', () => {
+    const rounds = [
+      makeRound(0),
+      makeToolCallRound(1, ['exec']),
+      makeSubagentRound(2),
     ];
 
-    const result = computeFishboneLayout(entries);
+    const result = computeFishboneLayout(rounds);
 
-    // All 7 nodes must be present — none should be discarded
-    expect(result.nodes).toHaveLength(7);
+    const normalColor = (result.nodes.find((n) => n.id === 'round-0')!.data as Record<string, unknown>).color;
+    const toolColor = (result.nodes.find((n) => n.id === 'round-1')!.data as Record<string, unknown>).color;
+    const subColor = (result.nodes.find((n) => n.id === 'round-2')!.data as Record<string, unknown>).color;
 
-    // Sub-branch nodes f and g should exist in the output
-    const nodeF = result.nodes.find((n) => n.id === 'f');
-    const nodeG = result.nodes.find((n) => n.id === 'g');
-    expect(nodeF).toBeDefined();
-    expect(nodeG).toBeDefined();
-
-    // f and g should be on a branch (not on the main spine y=0
-    // and not on the same branch as d/e)
-    const nodeD = result.nodes.find((n) => n.id === 'd')!;
-    expect(nodeF!.position.y).not.toBe(0);
-    // The sub-branch should be at a different Y than the parent branch
-    // (they might coincidentally land at same Y in some alternation patterns,
-    // but they should be separate branch entries with proper edges)
-
-    // Check edges: d→f and f→g should exist
-    const edgeDF = result.edges.find((e) => e.source === 'd' && e.target === 'f');
-    const edgeFG = result.edges.find((e) => e.source === 'f' && e.target === 'g');
-    expect(edgeDF).toBeDefined();
-    expect(edgeFG).toBeDefined();
-  });
-
-  it('handles deeply nested sub-branches (3 levels)', () => {
-    // Spine: a → b
-    // Branch from a: c → d
-    // Sub-branch from c: e → f
-    // Sub-sub-branch from e: g
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'a'), // branch from a
-      makeEntry('d', 'c'),
-      makeEntry('e', 'c'), // sub-branch from c
-      makeEntry('f', 'e'),
-      makeEntry('g', 'e'), // sub-sub-branch from e
-    ];
-
-    const result = computeFishboneLayout(entries);
-
-    // All 7 nodes present
-    expect(result.nodes).toHaveLength(7);
-
-    // All nodes reachable via edges
-    const nodeIds = new Set(result.nodes.map((n) => n.id));
-    expect(nodeIds).toEqual(new Set(['a', 'b', 'c', 'd', 'e', 'f', 'g']));
-
-    // Sub-sub-branch node g should exist and be connected
-    const edgeEG = result.edges.find((e) => e.source === 'e' && e.target === 'g');
-    expect(edgeEG).toBeDefined();
-  });
-
-  it('classifies subagent tool_use before generic tool_use', () => {
-    const subagentEntry = makeEntry('sa', undefined, 'message', {
-      message: {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool_use',
-            name: 'subagent_spawn',
-            id: 'tool_1',
-            input: {},
-          },
-        ],
-        usage: { input_tokens: 100, output_tokens: 50 },
-      },
-    });
-
-    const result = computeFishboneLayout([subagentEntry]);
-    const data = result.nodes[0].data as Record<string, unknown>;
-    expect(data.category).toBe('subagent');
+    expect(normalColor).toBe('#3b82f6');   // blue
+    expect(toolColor).toBe('#f97316');      // orange
+    expect(subColor).toBe('#a855f7');       // purple
   });
 
   it('includes token data in node data', () => {
-    const entries = [
-      makeEntry('a', undefined, 'message', {
-        message: {
-          role: 'assistant',
-          content: 'Hello',
-          usage: { input_tokens: 500, output_tokens: 200 },
-        },
-      }),
-    ];
+    const rounds = [makeRound(0, { totalTokens: 700 })];
 
-    const result = computeFishboneLayout(entries);
-    const node = result.nodes[0];
-    const data = node.data as Record<string, unknown>;
+    const result = computeFishboneLayout(rounds);
+    const data = result.nodes[0].data as Record<string, unknown>;
 
     expect(data.totalTokens).toBe(700);
     expect(data.nodeWidth).toBeGreaterThan(0);
     expect(data.nodeHeight).toBeGreaterThan(0);
   });
 
-  it('classifies subagent tool calls as subagent (not tool_call)', () => {
-    const entries = [
-      makeEntry('a', undefined, 'message', {
-        message: {
-          role: 'assistant',
-          content: [
-            { type: 'text', text: 'Spawning a subagent...' },
-            { type: 'tool_use', name: 'subagents', id: 'tu_1' },
-          ],
-          usage: { input_tokens: 100, output_tokens: 50 },
-        },
-      }),
+  it('connects expanded bones with edges in correct order', () => {
+    const rounds = [
+      makeRound(0),
+      makeToolCallRound(1, ['exec', 'read']),
+      makeRound(2),
     ];
+    const expanded = new Set(['round-1']);
+    const result = computeFishboneLayout(rounds, expanded);
 
-    const result = computeFishboneLayout(entries);
-    const data = result.nodes[0].data as Record<string, unknown>;
-    expect(data.category).toBe('subagent');
+    // 3 round nodes + 2 bone nodes = 5
+    expect(result.nodes).toHaveLength(5);
+
+    // Edges: round-0→round-1, round-1→round-2 (spine)
+    //      + round-1→bone-0, bone-0→bone-1 (bones)
+    expect(result.edges).toHaveLength(4);
+
+    // Spine edges
+    expect(result.edges.find((e) => e.source === 'round-0' && e.target === 'round-1')).toBeDefined();
+    expect(result.edges.find((e) => e.source === 'round-1' && e.target === 'round-2')).toBeDefined();
+
+    // Bone edges
+    expect(result.edges.find((e) => e.source === 'round-1' && e.target === 'round-1-bone-0')).toBeDefined();
+    expect(result.edges.find((e) => e.source === 'round-1-bone-0' && e.target === 'round-1-bone-1')).toBeDefined();
   });
 
-  it('classifies regular tool calls as tool_call (not subagent)', () => {
-    const entries = [
-      makeEntry('a', undefined, 'message', {
-        message: {
-          role: 'assistant',
-          content: [
-            { type: 'text', text: 'Reading file...' },
-            { type: 'tool_use', name: 'read', id: 'tu_2' },
-          ],
-          usage: { input_tokens: 100, output_tokens: 50 },
-        },
-      }),
+  it('all nodes have sessionNode type', () => {
+    const rounds = [
+      makeRound(0),
+      makeToolCallRound(1, ['exec']),
     ];
+    const expanded = new Set(['round-1']);
+    const result = computeFishboneLayout(rounds, expanded);
 
-    const result = computeFishboneLayout(entries);
-    const data = result.nodes[0].data as Record<string, unknown>;
-    expect(data.category).toBe('tool_call');
-  });
-
-  it('handles nested sub-branches (branch of a branch)', () => {
-    // Main spine: a → b → c
-    // Branch from a: d → e → f
-    // Sub-branch from e: g → h
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'b'),
-      makeEntry('d', 'a'),   // branch from a
-      makeEntry('e', 'd'),
-      makeEntry('f', 'e'),
-      makeEntry('g', 'e'),   // sub-branch from e (second child of e)
-      makeEntry('h', 'g'),
-    ];
-
-    const result = computeFishboneLayout(entries);
-
-    // All 8 nodes should be present
-    expect(result.nodes).toHaveLength(8);
-
-    const nodeIds = new Set(result.nodes.map((n) => n.id));
-    expect(nodeIds).toContain('g');
-    expect(nodeIds).toContain('h');
-
-    // Edges: a→b, b→c (spine), a→d, d→e, e→f (branch), e→g, g→h (sub-branch)
-    expect(result.edges).toHaveLength(7);
-
-    // Edge from e to g (sub-branch fork)
-    const subBranchEdge = result.edges.find(
-      (e) => e.source === 'e' && e.target === 'g'
-    );
-    expect(subBranchEdge).toBeDefined();
-
-    // Edge from g to h (within sub-branch)
-    const innerSubEdge = result.edges.find(
-      (e) => e.source === 'g' && e.target === 'h'
-    );
-    expect(innerSubEdge).toBeDefined();
-
-    // Sub-branch nodes should be at a different Y than both spine and parent branch
-    const nodeG = result.nodes.find((n) => n.id === 'g')!;
-    const nodeD = result.nodes.find((n) => n.id === 'd')!;
-    expect(nodeG.position.y).not.toBe(0);              // not on spine
-    expect(nodeG.position.y).not.toBe(nodeD.position.y); // not on parent branch
-  });
-
-  it('handles deeply nested sub-branches (3 levels)', () => {
-    // Spine:          a → b
-    // Branch L1:      c (from a)
-    // Sub-branch L2:  d (from c, second child)
-    // Sub-branch L3:  e (from d, second child)
-    const entries = [
-      makeEntry('a', undefined, 'session'),
-      makeEntry('b', 'a'),
-      makeEntry('c', 'a'),   // L1 branch from a
-      makeEntry('c2', 'c'),  // first child of c (continues L1)
-      makeEntry('d', 'c'),   // L2 sub-branch from c
-      makeEntry('d2', 'd'),  // first child of d (continues L2)
-      makeEntry('e', 'd'),   // L3 sub-branch from d
-    ];
-
-    const result = computeFishboneLayout(entries);
-
-    // All 7 nodes present
-    expect(result.nodes).toHaveLength(7);
-
-    const nodeIds = new Set(result.nodes.map((n) => n.id));
-    for (const id of ['a', 'b', 'c', 'c2', 'd', 'd2', 'e']) {
-      expect(nodeIds).toContain(id);
+    for (const node of result.nodes) {
+      expect(node.type).toBe('sessionNode');
     }
-
-    // Verify fork edges exist
-    expect(result.edges.find((e) => e.source === 'a' && e.target === 'c')).toBeDefined();
-    expect(result.edges.find((e) => e.source === 'c' && e.target === 'd')).toBeDefined();
-    expect(result.edges.find((e) => e.source === 'd' && e.target === 'e')).toBeDefined();
-
-    // All three branch levels should be at distinct Y positions
-    const yC = result.nodes.find((n) => n.id === 'c')!.position.y;
-    const yD = result.nodes.find((n) => n.id === 'd')!.position.y;
-    const yE = result.nodes.find((n) => n.id === 'e')!.position.y;
-
-    const ys = new Set([0, yC, yD, yE]);
-    expect(ys.size).toBe(4); // spine + 3 distinct branch Y levels
   });
 
-  it('extracts preview from array content blocks', () => {
-    const entries = [
-      makeEntry('a', undefined, 'message', {
-        message: {
-          role: 'user',
-          content: [
-            { type: 'text', text: 'Hello from array content!' },
-          ],
-          usage: { input_tokens: 10, output_tokens: 0 },
-        },
-      }),
+  it('generates preview with tool names', () => {
+    const rounds = [
+      makeToolCallRound(0, ['exec', 'read', 'web_search', 'write']),
     ];
+    const result = computeFishboneLayout(rounds);
+    const preview = (result.nodes[0].data as Record<string, unknown>).preview as string;
 
-    const result = computeFishboneLayout(entries);
-    const data = result.nodes[0].data as Record<string, unknown>;
-    expect(data.preview).toBe('Hello from array content!');
+    // Should contain "Round 1" and some tool names
+    expect(preview).toContain('Round 1');
+    expect(preview).toContain('exec');
+  });
+
+  it('handles many rounds efficiently', () => {
+    const rounds = Array.from({ length: 50 }, (_, i) => makeRound(i));
+    const result = computeFishboneLayout(rounds);
+
+    expect(result.nodes).toHaveLength(50);
+    expect(result.edges).toHaveLength(49);
+
+    // All on spine
+    for (const node of result.nodes) {
+      expect(node.position.y).toBe(0);
+    }
   });
 });
 

--- a/src/layout/fishbone.ts
+++ b/src/layout/fishbone.ts
@@ -1,239 +1,101 @@
-// ── Fishbone layout algorithm ─────────────────────────────────────────
+// ── Fishbone layout algorithm (Round-based) ──────────────────────────
 //
-// Input:  TranscriptEntry[] (with id/parentId tree structure)
+// Input:  Round[] (grouped from transcript entries) + expanded round ids
 // Output: React Flow Node[] and Edge[]
 //
 // Layout rules:
-//   - Horizontal left-to-right
-//   - Main spine at Y=0
-//   - Subagent branches offset ±Y from the spine
-//   - X = sequential index × spacing
-//   - No external layout library required
+//   - Main spine: one node per round, horizontal left-to-right at Y=0
+//   - Tool call "bones": when a round is expanded, its tool calls appear
+//     as small nodes below the round node (vertical fishbone ribs)
+//   - Node colour encodes round type (normal / tool_call / subagent)
+//   - Node size ∝ token count
 
 import type { Node, Edge } from '@xyflow/react';
-import type { TranscriptEntry } from '@/gateway/types';
-import type { EntryCategory, LayoutEntry } from './types';
+import type { Round, RoundType } from './types';
 import { computeNodeSize } from './node-sizing';
-import { CATEGORY_COLORS } from './types';
+import { ROUND_COLORS } from './types';
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const X_SPACING = 220;      // px between nodes horizontally
-const Y_SPACING = 180;      // px between branch levels vertically
-const X_OFFSET = 60;        // left margin
+const X_SPACING = 220;       // px between round nodes horizontally
+const Y_BONE_SPACING = 80;   // px between tool-call bone nodes vertically
+const X_OFFSET = 60;         // left margin
 
 // ── Types for React Flow data ────────────────────────────────────────
 
 export interface SessionNodeData {
+  // Common fields
   entryId: string;
-  type: string;
-  category: EntryCategory;
-  role: string;
-  preview: string;
-  totalTokens: number;
   color: string;
   nodeWidth: number;
   nodeHeight: number;
   timestamp?: string;
+  totalTokens: number;
+
+  // Round-specific fields (present on round nodes)
+  /** Identifies this node as a round node. */
+  isRound: boolean;
+  /** Round type for colour encoding. */
+  roundType: RoundType;
+  /** Short label like "Round 3: exec, read → response…" */
+  preview: string;
+  /** Number of tool calls in this round (for badge). */
+  toolCallCount: number;
+  /** Whether the round is currently expanded (showing bones). */
+  expanded: boolean;
+  /** Whether this round has subagent spawns. */
+  hasSubagent: boolean;
+  /** Tooltip: user prompt (first 200 chars). */
+  userPreview: string;
+  /** Tooltip: assistant response (first 200 chars). */
+  assistantPreview: string;
+
+  // Tool-call bone fields (present on bone nodes)
+  /** Identifies this node as a tool-call bone. */
+  isBone: boolean;
+  /** Tool name (e.g. "exec", "read"). */
+  toolName: string;
+
+  // Legacy compatibility fields
+  type: string;
+  category: string;
+  role: string;
+
   [key: string]: unknown;
 }
 
-// ── Category classification ──────────────────────────────────────────
+// ── Preview helpers ──────────────────────────────────────────────────
 
-function classifyEntry(entry: TranscriptEntry): EntryCategory {
-  if (entry.type === 'message' && entry.message) {
-    const content = entry.message.content;
-    // Check for tool calls in content (array with tool_use blocks)
-    if (Array.isArray(content)) {
-      // Check subagent first — a subagent spawn is also a tool_use,
-      // so this must come before the generic tool_use check.
-      const hasSubagent = content.some(
-        (block) =>
-          typeof block === 'object' &&
-          block !== null &&
-          (block as Record<string, unknown>).type === 'tool_use' &&
-          typeof (block as Record<string, unknown>).name === 'string' &&
-          ((block as Record<string, unknown>).name as string).includes('subagent')
-      );
-      if (hasSubagent) return 'subagent';
-
-      const hasToolUse = content.some(
-        (block) =>
-          typeof block === 'object' &&
-          block !== null &&
-          (block as Record<string, unknown>).type === 'tool_use'
-      );
-      if (hasToolUse) return 'tool_call';
-    }
-
-    // Tool role messages are tool results
-    if (entry.message.role === 'tool') return 'tool_call';
-
-    return 'conversation';
+function extractTextPreview(entry: import('@/gateway/types').TranscriptEntry | undefined, maxLen = 200): string {
+  if (!entry?.message) return '';
+  const content = entry.message.content;
+  if (typeof content === 'string') return content.slice(0, maxLen);
+  if (Array.isArray(content)) {
+    const textBlock = content.find((b: any) => b.type === 'text' && b.text);
+    if (textBlock?.text) return (textBlock.text as string).slice(0, maxLen);
   }
-
-  if (entry.type === 'branch_summary') return 'subagent';
-
-  // compaction, model_change, session, custom, etc.
-  return 'system';
+  return '';
 }
 
-function extractPreview(entry: TranscriptEntry): string {
-  if (entry.type === 'message' && entry.message) {
-    const content = entry.message.content;
-    if (typeof content === 'string') {
-      return content.slice(0, 80);
-    }
-    if (Array.isArray(content)) {
-      const textBlock = content.find((b) => b.type === 'text');
-      if (textBlock?.text) {
-        return textBlock.text.slice(0, 80);
-      }
-    }
-    return `[${entry.message.role}]`;
+function buildRoundPreview(round: Round, index: number): string {
+  const parts: string[] = [];
+
+  // Tool names summary
+  if (round.toolCalls.length > 0) {
+    const toolNames = [...new Set(round.toolCalls.map((tc) => tc.name))];
+    const shown = toolNames.slice(0, 3).join(', ');
+    const extra = toolNames.length > 3 ? ` +${toolNames.length - 3}` : '';
+    parts.push(`${shown}${extra}`);
   }
 
-  if (entry.type === 'compaction') return `Compaction: ${entry.summary?.slice(0, 60) ?? '…'}`;
-  if (entry.type === 'model_change') return 'Model Change';
-  if (entry.type === 'session') return 'Session Start';
-  if (entry.type === 'branch_summary') return `Branch: ${entry.summary?.slice(0, 60) ?? '…'}`;
-
-  return entry.type;
-}
-
-function extractTokens(entry: TranscriptEntry): number {
-  if (entry.type === 'message' && entry.message?.usage) {
-    const u = entry.message.usage;
-    return (u.input_tokens ?? 0) + (u.output_tokens ?? 0);
-  }
-  if (entry.type === 'compaction' && entry.tokensBefore) {
-    return entry.tokensBefore;
-  }
-  return 0;
-}
-
-// ── Tree building ────────────────────────────────────────────────────
-
-function buildTree(entries: TranscriptEntry[]): LayoutEntry[] {
-  if (entries.length === 0) return [];
-
-  const map = new Map<string, LayoutEntry>();
-  const roots: LayoutEntry[] = [];
-
-  // Create LayoutEntry for each transcript entry
-  for (const entry of entries) {
-    const le: LayoutEntry = {
-      id: entry.id,
-      parentId: entry.parentId,
-      type: entry.type,
-      category: classifyEntry(entry),
-      role: entry.message?.role,
-      preview: extractPreview(entry),
-      totalTokens: extractTokens(entry),
-      timestamp: entry.timestamp,
-      children: [],
-      depth: 0,
-      index: 0,
-    };
-    map.set(entry.id, le);
+  // Response snippet
+  const response = extractTextPreview(round.assistantMessage, 60);
+  if (response) {
+    parts.push(`→ ${response}`);
   }
 
-  // Link parents ↔ children
-  for (const le of map.values()) {
-    if (le.parentId && map.has(le.parentId)) {
-      map.get(le.parentId)!.children.push(le);
-    } else {
-      roots.push(le);
-    }
-  }
-
-  return roots;
-}
-
-// ── Spine / branch extraction ────────────────────────────────────────
-
-/** A collected branch: the first node's parent ID + the X slot where it forks. */
-interface BranchRecord {
-  /** ID of the parent node this branch forks from. */
-  parentNodeId: string;
-  /** Global X-slot of the parent node (used to position the branch). */
-  parentXSlot: number;
-  /** Linear list of entries along this branch's first-child spine. */
-  entries: LayoutEntry[];
-}
-
-interface SpineResult {
-  spine: LayoutEntry[];
-  branches: BranchRecord[];
-}
-
-function extractSpineAndBranches(roots: LayoutEntry[]): SpineResult {
-  const spine: LayoutEntry[] = [];
-  const branches: BranchRecord[] = [];
-
-  if (roots.length === 0) return { spine, branches };
-
-  // Start from first root
-  let current: LayoutEntry | undefined = roots[0];
-
-  // If multiple roots, treat extras as branches from slot 0
-  for (let i = 1; i < roots.length; i++) {
-    collectBranch(roots[i], roots[0].id, 0, branches);
-  }
-
-  let slot = 0;
-  while (current) {
-    current.index = slot;
-    current.depth = 0;
-    spine.push(current);
-
-    // Extra children become branches
-    for (let c = 1; c < current.children.length; c++) {
-      collectBranch(current.children[c], current.id, slot, branches);
-    }
-
-    current = current.children[0]; // Follow first child
-    slot++;
-  }
-
-  return { spine, branches };
-}
-
-/**
- * Collect a branch (first-child spine) and recursively collect any
- * nested sub-branches as additional top-level branches.
- *
- * @param root         Root of the subtree to collect
- * @param parentNodeId ID of the node this branch forks from
- * @param parentXSlot  Global X-slot of the parent node
- * @param branches     Accumulated branches array (mutated)
- */
-function collectBranch(
-  root: LayoutEntry,
-  parentNodeId: string,
-  parentXSlot: number,
-  branches: BranchRecord[]
-): void {
-  const entries: LayoutEntry[] = [];
-  let current: LayoutEntry | undefined = root;
-  let idx = 0;
-
-  while (current) {
-    current.index = idx;
-    entries.push(current);
-
-    // Any additional children become their own sub-branches.
-    // The parent is the current node; its X-slot = parentXSlot + 1 + idx.
-    const currentXSlot = parentXSlot + 1 + idx;
-    for (let c = 1; c < current.children.length; c++) {
-      collectBranch(current.children[c], current.id, currentXSlot, branches);
-    }
-
-    current = current.children[0];
-    idx++;
-  }
-
-  branches.push({ parentNodeId, parentXSlot, entries });
+  const detail = parts.length > 0 ? `: ${parts.join(' ')}` : '';
+  return `Round ${index + 1}${detail}`;
 }
 
 // ── Layout computation ───────────────────────────────────────────────
@@ -244,81 +106,117 @@ export interface FishboneResult {
 }
 
 /**
- * Compute fishbone layout from transcript entries.
+ * Compute fishbone layout from rounds.
  *
- * @param entries - Transcript entries (with id/parentId tree structure)
+ * @param rounds - Grouped rounds from transcript
+ * @param expandedRounds - Set of round ids that are currently expanded
  * @returns React Flow nodes and edges positioned in a fishbone pattern
  */
-export function computeFishboneLayout(entries: TranscriptEntry[]): FishboneResult {
-  if (entries.length === 0) {
+export function computeFishboneLayout(
+  rounds: Round[],
+  expandedRounds: Set<string> = new Set()
+): FishboneResult {
+  if (rounds.length === 0) {
     return { nodes: [], edges: [] };
   }
-
-  const roots = buildTree(entries);
-  const { spine, branches } = extractSpineAndBranches(roots);
 
   const nodes: Node<SessionNodeData>[] = [];
   const edges: Edge[] = [];
 
-  // ── Helper to create a node ──
-  function makeNode(entry: LayoutEntry, x: number, y: number): void {
-    const { width, height } = computeNodeSize(entry.totalTokens);
+  // ── Lay out main spine (Y = 0) ──
+  for (let i = 0; i < rounds.length; i++) {
+    const round = rounds[i];
+    const { width, height } = computeNodeSize(round.totalTokens);
+    const x = X_OFFSET + i * X_SPACING;
+    const y = 0;
+    const isExpanded = expandedRounds.has(round.id);
+    const preview = buildRoundPreview(round, i);
+
     nodes.push({
-      id: entry.id,
+      id: round.id,
       type: 'sessionNode',
       position: { x, y },
       data: {
-        entryId: entry.id,
-        type: entry.type,
-        category: entry.category,
-        role: entry.role ?? entry.type,
-        preview: entry.preview,
-        totalTokens: entry.totalTokens,
-        color: CATEGORY_COLORS[entry.category],
+        entryId: round.id,
+        color: ROUND_COLORS[round.type],
         nodeWidth: width,
         nodeHeight: height,
-        timestamp: entry.timestamp,
+        timestamp: round.timestamp,
+        totalTokens: round.totalTokens,
+
+        isRound: true,
+        roundType: round.type,
+        preview,
+        toolCallCount: round.toolCalls.length,
+        expanded: isExpanded,
+        hasSubagent: round.subagentSpawns.length > 0,
+        userPreview: extractTextPreview(round.userMessage),
+        assistantPreview: extractTextPreview(round.assistantMessage),
+
+        isBone: false,
+        toolName: '',
+
+        type: 'round',
+        category: round.type === 'normal' ? 'conversation' : round.type,
+        role: 'round',
       },
     });
-  }
 
-  function makeEdge(sourceId: string, targetId: string): void {
-    edges.push({
-      id: `e-${sourceId}-${targetId}`,
-      source: sourceId,
-      target: targetId,
-      type: 'branchEdge',
-    });
-  }
-
-  // ── Lay out main spine (Y = 0) ──
-  for (let i = 0; i < spine.length; i++) {
-    makeNode(spine[i], X_OFFSET + i * X_SPACING, 0);
+    // Edge to previous round
     if (i > 0) {
-      makeEdge(spine[i - 1].id, spine[i].id);
+      edges.push({
+        id: `e-${rounds[i - 1].id}-${round.id}`,
+        source: rounds[i - 1].id,
+        target: round.id,
+        type: 'branchEdge',
+      });
     }
-  }
 
-  // ── Lay out branches ──
-  // Alternate direction: odd branches go up (−Y), even go down (+Y)
-  let branchDirectionCounter = 0;
+    // ── Tool call bones (if expanded) ──
+    if (isExpanded && round.toolCalls.length > 0) {
+      for (let j = 0; j < round.toolCalls.length; j++) {
+        const tc = round.toolCalls[j];
+        const boneId = `${round.id}-bone-${j}`;
+        const boneY = y + height + 20 + j * Y_BONE_SPACING;
 
-  for (const branch of branches) {
-    branchDirectionCounter++;
-    const direction = branchDirectionCounter % 2 === 0 ? 1 : -1;
-    const yOffset = direction * Y_SPACING * Math.ceil(branchDirectionCounter / 2);
+        nodes.push({
+          id: boneId,
+          type: 'sessionNode',
+          position: { x: x + 20, y: boneY },
+          data: {
+            entryId: boneId,
+            color: '#f97316',
+            nodeWidth: 120,
+            nodeHeight: 36,
+            timestamp: undefined,
+            totalTokens: 0,
 
-    for (let j = 0; j < branch.entries.length; j++) {
-      const entry = branch.entries[j];
-      const x = X_OFFSET + (branch.parentXSlot + 1 + j) * X_SPACING;
+            isRound: false,
+            roundType: 'tool_call',
+            preview: tc.name,
+            toolCallCount: 0,
+            expanded: false,
+            hasSubagent: false,
+            userPreview: '',
+            assistantPreview: tc.resultContent?.slice(0, 200) ?? '',
 
-      makeNode(entry, x, yOffset);
+            isBone: true,
+            toolName: tc.name,
 
-      if (j === 0) {
-        // Edge from parent node to first branch node
-        makeEdge(branch.parentNodeId, entry.id);
-      } else {
-        makeEdge(branch.entries[j - 1].id, entry.id);
+            type: 'tool_call',
+            category: 'tool_call',
+            role: 'tool',
+          },
+        });
+
+        // Edge from round node (or previous bone) to this bone
+        const sourceId = j === 0 ? round.id : `${round.id}-bone-${j - 1}`;
+        edges.push({
+          id: `e-${sourceId}-${boneId}`,
+          source: sourceId,
+          target: boneId,
+          type: 'branchEdge',
+        });
       }
     }
   }

--- a/src/layout/types.ts
+++ b/src/layout/types.ts
@@ -7,6 +7,9 @@ export type EntryCategory =
   | 'subagent'       // Entry that spawned a subagent
   | 'system';        // compaction, model_change, etc.
 
+/** Round type — matches EntryCategory but uses the spec naming. */
+export type RoundType = 'normal' | 'tool_call' | 'subagent';
+
 /** Computed dimensions for a node. */
 export interface NodeDimensions {
   width: number;
@@ -30,10 +33,54 @@ export interface LayoutEntry {
   index: number;
 }
 
+/** A single tool call within a round (tool_use + optional tool_result). */
+export interface ToolCallInfo {
+  /** tool_use block id. */
+  id?: string;
+  /** Tool name (e.g. "exec", "read", "web_search"). */
+  name: string;
+  /** Raw tool_use block. */
+  toolUseBlock: unknown;
+  /** Corresponding tool result content (if found). */
+  resultContent?: string;
+}
+
+/**
+ * A "round" groups one user→assistant interaction cycle.
+ * Multiple intermediate tool calls are folded into the round.
+ */
+export interface Round {
+  /** Stable id: "round-0", "round-1", … */
+  id: string;
+  /** The user message that started this round (may be absent for system-initiated). */
+  userMessage?: import('@/gateway/types').TranscriptEntry;
+  /** The final assistant reply (the one sent to the IM channel). */
+  assistantMessage?: import('@/gateway/types').TranscriptEntry;
+  /** Intermediate tool call pairs (tool_use → tool_result). */
+  toolCalls: ToolCallInfo[];
+  /** Session keys of subagents spawned during this round. */
+  subagentSpawns: string[];
+  /** All raw entries belonging to this round (for detail view). */
+  rawEntries: import('@/gateway/types').TranscriptEntry[];
+  /** Sum of all tokens consumed in this round. */
+  totalTokens: number;
+  /** Timestamp of the first message in the round. */
+  timestamp?: string;
+  /** Classification for colour coding. */
+  type: RoundType;
+}
+
 /** Color mapping for entry categories. */
 export const CATEGORY_COLORS: Record<EntryCategory, string> = {
   conversation: '#3b82f6',  // blue
   tool_call:    '#f97316',  // orange
-  subagent:     '#22c55e',  // green
+  subagent:     '#a855f7',  // purple  (was green, now purple per spec)
   system:       '#9ca3af',  // gray
+};
+
+/** Color mapping for round types. */
+export const ROUND_COLORS: Record<RoundType, string> = {
+  normal:    '#3b82f6',  // blue  — pure conversation
+  tool_call: '#f97316',  // orange — has tool calls
+  subagent:  '#a855f7',  // purple — spawned a subagent
 };

--- a/src/store/transcript.test.ts
+++ b/src/store/transcript.test.ts
@@ -1,0 +1,177 @@
+// ── Round grouping tests ─────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { groupIntoRounds } from './transcript';
+import type { TranscriptEntry } from '@/gateway/types';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function msg(
+  id: string,
+  role: 'user' | 'assistant' | 'tool' | 'system',
+  content: string | any[] = 'hello',
+  extra: Partial<TranscriptEntry> = {}
+): TranscriptEntry {
+  return {
+    id,
+    type: 'message',
+    message: {
+      role,
+      content,
+      usage: { input_tokens: 50, output_tokens: 50 },
+    },
+    timestamp: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+function sessionEntry(id: string): TranscriptEntry {
+  return {
+    id,
+    type: 'session',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('groupIntoRounds', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupIntoRounds([])).toEqual([]);
+  });
+
+  it('groups a simple user→assistant pair into one round', () => {
+    const entries = [
+      msg('1', 'user', 'What is 2+2?'),
+      msg('2', 'assistant', 'It is 4.'),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].id).toBe('round-0');
+    expect(rounds[0].type).toBe('normal');
+    expect(rounds[0].userMessage?.id).toBe('1');
+    expect(rounds[0].assistantMessage?.id).toBe('2');
+    expect(rounds[0].toolCalls).toHaveLength(0);
+    expect(rounds[0].totalTokens).toBe(200); // 2 messages × (50+50)
+  });
+
+  it('groups multiple conversation turns into separate rounds', () => {
+    const entries = [
+      msg('1', 'user', 'Hello'),
+      msg('2', 'assistant', 'Hi!'),
+      msg('3', 'user', 'How are you?'),
+      msg('4', 'assistant', 'Good!'),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    expect(rounds).toHaveLength(2);
+    expect(rounds[0].userMessage?.id).toBe('1');
+    expect(rounds[0].assistantMessage?.id).toBe('2');
+    expect(rounds[1].userMessage?.id).toBe('3');
+    expect(rounds[1].assistantMessage?.id).toBe('4');
+  });
+
+  it('collects tool calls in a single round', () => {
+    const entries = [
+      msg('1', 'user', 'Read the file'),
+      msg('2', 'assistant', [
+        { type: 'text', text: 'Reading...' },
+        { type: 'tool_use', name: 'read', id: 'tu_1', input: { path: 'foo.ts' } },
+      ]),
+      msg('3', 'tool', [
+        { type: 'tool_result', tool_use_id: 'tu_1', content: 'file contents here' },
+      ]),
+      msg('4', 'assistant', 'Here is the file content...'),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].type).toBe('tool_call');
+    expect(rounds[0].toolCalls).toHaveLength(1);
+    expect(rounds[0].toolCalls[0].name).toBe('read');
+    expect(rounds[0].toolCalls[0].resultContent).toBe('file contents here');
+    expect(rounds[0].assistantMessage?.id).toBe('4'); // final response
+  });
+
+  it('collects multiple tool calls in one round', () => {
+    const entries = [
+      msg('1', 'user', 'Do stuff'),
+      msg('2', 'assistant', [
+        { type: 'tool_use', name: 'exec', id: 'tu_1', input: {} },
+      ]),
+      msg('3', 'tool', [
+        { type: 'tool_result', tool_use_id: 'tu_1', content: 'output1' },
+      ]),
+      msg('4', 'assistant', [
+        { type: 'tool_use', name: 'read', id: 'tu_2', input: {} },
+      ]),
+      msg('5', 'tool', [
+        { type: 'tool_result', tool_use_id: 'tu_2', content: 'output2' },
+      ]),
+      msg('6', 'assistant', 'All done.'),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].type).toBe('tool_call');
+    expect(rounds[0].toolCalls).toHaveLength(2);
+    expect(rounds[0].toolCalls[0].name).toBe('exec');
+    expect(rounds[0].toolCalls[1].name).toBe('read');
+    expect(rounds[0].assistantMessage?.id).toBe('6');
+    expect(rounds[0].rawEntries).toHaveLength(6);
+  });
+
+  it('identifies subagent rounds', () => {
+    const entries = [
+      msg('1', 'user', 'Spawn a sub'),
+      msg('2', 'assistant', [
+        { type: 'text', text: 'Spawning...' },
+        { type: 'tool_use', name: 'subagents', id: 'tu_1', input: {} },
+      ]),
+      msg('3', 'tool', [
+        { type: 'tool_result', tool_use_id: 'tu_1', content: 'spawned' },
+      ]),
+      msg('4', 'assistant', 'Done spawning.'),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].type).toBe('subagent');
+    expect(rounds[0].subagentSpawns.length).toBeGreaterThan(0);
+  });
+
+  it('handles pre-user system entries', () => {
+    const entries = [
+      sessionEntry('s1'),
+      msg('1', 'user', 'Hi'),
+      msg('2', 'assistant', 'Hello!'),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    // System entry before first user → its own round
+    // Then user→assistant → second round
+    expect(rounds).toHaveLength(2);
+    expect(rounds[0].rawEntries).toHaveLength(1);
+    expect(rounds[0].rawEntries[0].id).toBe('s1');
+    expect(rounds[1].userMessage?.id).toBe('1');
+  });
+
+  it('handles round with no final text assistant message', () => {
+    // Assistant only produced tool calls, never a plain text reply
+    const entries = [
+      msg('1', 'user', 'Do thing'),
+      msg('2', 'assistant', [
+        { type: 'tool_use', name: 'exec', id: 'tu_1', input: {} },
+      ]),
+      msg('3', 'tool', [
+        { type: 'tool_result', tool_use_id: 'tu_1', content: 'result' },
+      ]),
+    ];
+    const rounds = groupIntoRounds(entries);
+
+    expect(rounds).toHaveLength(1);
+    // Post-processing should set assistantMessage to the last assistant entry
+    expect(rounds[0].assistantMessage?.id).toBe('2');
+  });
+});

--- a/src/store/transcript.ts
+++ b/src/store/transcript.ts
@@ -2,12 +2,188 @@
 //
 // Manages the currently-selected session's transcript data and
 // the computed fishbone graph layout.
+//
+// Key concept: **Rounds**.
+// Raw chat.history messages are grouped into "rounds" where each round
+// is one user→assistant interaction cycle.  Multiple tool calls within
+// a single cycle are folded into the round.
 
 import { create } from 'zustand';
 import type { Node, Edge } from '@xyflow/react';
-import type { TranscriptEntry } from '@/gateway/types';
+import type { TranscriptEntry, ContentBlock } from '@/gateway/types';
+import type { Round, ToolCallInfo, RoundType } from '@/layout/types';
 import { computeFishboneLayout, type SessionNodeData } from '@/layout/fishbone';
 import { useConnectionStore } from './connection';
+
+// ── Round grouping logic ─────────────────────────────────────────────
+
+/**
+ * Group flat transcript entries into rounds.
+ *
+ * A round starts at a `user` message and includes every subsequent
+ * assistant / tool message until the next `user` message (or end).
+ *
+ * System / compaction / session entries that appear before the first
+ * user message form a special "system" round.
+ */
+export function groupIntoRounds(entries: TranscriptEntry[]): Round[] {
+  if (entries.length === 0) return [];
+
+  const rounds: Round[] = [];
+  let currentRound: Round | null = null;
+  let roundIndex = 0;
+
+  function finishRound() {
+    if (currentRound) {
+      // Determine round type
+      currentRound.type = classifyRound(currentRound);
+      rounds.push(currentRound);
+    }
+  }
+
+  function newRound(): Round {
+    const round: Round = {
+      id: `round-${roundIndex++}`,
+      toolCalls: [],
+      subagentSpawns: [],
+      rawEntries: [],
+      totalTokens: 0,
+      type: 'normal',
+    };
+    return round;
+  }
+
+  for (const entry of entries) {
+    const role = entry.message?.role;
+
+    // Start a new round on every user message
+    if (role === 'user') {
+      finishRound();
+      currentRound = newRound();
+      currentRound.userMessage = entry;
+      currentRound.timestamp = entry.timestamp;
+      currentRound.rawEntries.push(entry);
+      currentRound.totalTokens += extractEntryTokens(entry);
+      continue;
+    }
+
+    // If no round has been started yet, create one for pre-user messages
+    if (!currentRound) {
+      currentRound = newRound();
+      // For non-user entries before the first user message (session start, etc.)
+      if (entry.timestamp) currentRound.timestamp = entry.timestamp;
+    }
+
+    currentRound.rawEntries.push(entry);
+    currentRound.totalTokens += extractEntryTokens(entry);
+
+    if (role === 'assistant' && entry.type === 'message') {
+      // Check if this assistant message has tool calls
+      const toolUseBlocks = extractToolUseBlocks(entry);
+      if (toolUseBlocks.length > 0) {
+        // This is an intermediate assistant message with tool calls
+        for (const block of toolUseBlocks) {
+          const tcInfo: ToolCallInfo = {
+            id: block.id as string | undefined,
+            name: (block.name as string) ?? 'unknown',
+            toolUseBlock: block,
+          };
+
+          // Check for subagent spawn
+          const toolName = tcInfo.name;
+          if (
+            toolName.includes('subagent') ||
+            toolName === 'sessions_spawn'
+          ) {
+            // Try to extract session key from input
+            const input = block.input as Record<string, unknown> | undefined;
+            if (input?.sessionKey) {
+              currentRound.subagentSpawns.push(input.sessionKey as string);
+            } else {
+              currentRound.subagentSpawns.push(`subagent-from-${entry.id}`);
+            }
+          }
+
+          currentRound.toolCalls.push(tcInfo);
+        }
+        // Don't set as assistantMessage yet — there may be more tool calls
+        // The LAST assistant message without tool calls (or the last one period) wins
+      } else {
+        // Pure text assistant reply — this is (likely) the final response
+        currentRound.assistantMessage = entry;
+      }
+    } else if (role === 'tool') {
+      // Match tool result to its tool_use by tool_use_id
+      const content = entry.message?.content;
+      let toolUseId: string | undefined;
+      let resultText: string | undefined;
+
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.tool_use_id) {
+            toolUseId = block.tool_use_id as string;
+            resultText = typeof block.content === 'string'
+              ? block.content
+              : block.text ?? JSON.stringify(block.content ?? block, null, 2);
+          }
+        }
+      } else if (typeof content === 'string') {
+        resultText = content;
+        const data = entry.data as Record<string, unknown> | undefined;
+        toolUseId = data?.tool_use_id as string | undefined;
+      }
+
+      if (toolUseId) {
+        const tc = currentRound.toolCalls.find((t) => t.id === toolUseId);
+        if (tc) tc.resultContent = resultText;
+      }
+    }
+    // Other entry types (compaction, model_change, etc.) are just collected
+  }
+
+  // Finish last round
+  finishRound();
+
+  // Post-process: if a round has no explicit assistantMessage but has tool calls,
+  // the last assistant entry with tool calls becomes the assistantMessage
+  for (const round of rounds) {
+    if (!round.assistantMessage) {
+      const lastAssistant = [...round.rawEntries]
+        .reverse()
+        .find((e) => e.message?.role === 'assistant');
+      if (lastAssistant) round.assistantMessage = lastAssistant;
+    }
+  }
+
+  return rounds;
+}
+
+function extractToolUseBlocks(entry: TranscriptEntry): ContentBlock[] {
+  const content = entry.message?.content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(
+    (b) => typeof b === 'object' && b !== null && b.type === 'tool_use'
+  ) as ContentBlock[];
+}
+
+function extractEntryTokens(entry: TranscriptEntry): number {
+  if (entry.message?.usage) {
+    const u = entry.message.usage;
+    return (u.input_tokens ?? 0) + (u.output_tokens ?? 0);
+  }
+  if (entry.type === 'compaction' && entry.tokensBefore) {
+    return entry.tokensBefore;
+  }
+  return 0;
+}
+
+function classifyRound(round: Round): RoundType {
+  if (round.subagentSpawns.length > 0) return 'subagent';
+  if (round.toolCalls.length > 0) return 'tool_call';
+  return 'normal';
+}
+
+// ── Store ────────────────────────────────────────────────────────────
 
 interface TranscriptStore {
   // ── State ──
@@ -15,12 +191,16 @@ interface TranscriptStore {
   sessionKey: string | null;
   /** Raw transcript entries for the current session. */
   entries: TranscriptEntry[];
+  /** Grouped rounds (derived from entries). */
+  rounds: Round[];
   /** React Flow nodes (computed from layout). */
   graphNodes: Node<SessionNodeData>[];
   /** React Flow edges (computed from layout). */
   graphEdges: Edge[];
-  /** Currently selected node id. */
+  /** Currently selected node id (round id or tool-call id). */
   selectedNodeId: string | null;
+  /** Set of expanded round ids (showing tool call bones). */
+  expandedRounds: Set<string>;
   /** Whether transcript is being loaded. */
   loading: boolean;
   /** Last error from loading. */
@@ -29,10 +209,12 @@ interface TranscriptStore {
   // ── Actions ──
   /** Load transcript for a session from the gateway. */
   loadTranscript: (sessionKey: string) => Promise<void>;
-  /** Recompute the fishbone layout from current entries. */
+  /** Recompute the fishbone layout from current rounds. */
   computeLayout: () => void;
   /** Set selected node. */
   selectNode: (nodeId: string | null) => void;
+  /** Toggle expanded state for a round (show/hide tool call bones). */
+  toggleRound: (roundId: string) => void;
   /** Clear the transcript (e.g. on disconnect). */
   clear: () => void;
 }
@@ -40,9 +222,11 @@ interface TranscriptStore {
 export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
   sessionKey: null,
   entries: [],
+  rounds: [],
   graphNodes: [],
   graphEdges: [],
   selectedNodeId: null,
+  expandedRounds: new Set(),
   loading: false,
   error: null,
 
@@ -53,7 +237,7 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       return;
     }
 
-    set({ loading: true, error: null, sessionKey });
+    set({ loading: true, error: null, sessionKey, expandedRounds: new Set() });
 
     try {
       const result = await client.request<{ sessionKey: string; messages: unknown[] }>(
@@ -64,8 +248,6 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       const rawMessages = result?.messages ?? [];
 
       // Transform raw gateway messages into TranscriptEntry format.
-      // chat.history returns flat messages with { role, content, timestamp, ... }
-      // but the fishbone layout expects TranscriptEntry with { id, type, message }.
       const entries: TranscriptEntry[] = rawMessages.map((msg: any, index: number) => ({
         id: msg.id ?? `msg-${index}`,
         parentId: msg.parentId ?? (index > 0 ? (rawMessages[index - 1] as any).id ?? `msg-${index - 1}` : undefined),
@@ -83,7 +265,9 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
         timestamp: msg.timestamp ? new Date(msg.timestamp).toISOString() : undefined,
       }));
 
-      set({ entries, loading: false });
+      const rounds = groupIntoRounds(entries);
+
+      set({ entries, rounds, loading: false });
       get().computeLayout();
     } catch (err) {
       set({
@@ -94,8 +278,8 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
   },
 
   computeLayout: () => {
-    const { entries } = get();
-    const { nodes, edges } = computeFishboneLayout(entries);
+    const { rounds, expandedRounds } = get();
+    const { nodes, edges } = computeFishboneLayout(rounds, expandedRounds);
     set({ graphNodes: nodes, graphEdges: edges });
   },
 
@@ -103,13 +287,27 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
     set({ selectedNodeId: nodeId });
   },
 
+  toggleRound: (roundId: string) => {
+    const { expandedRounds } = get();
+    const next = new Set(expandedRounds);
+    if (next.has(roundId)) {
+      next.delete(roundId);
+    } else {
+      next.add(roundId);
+    }
+    set({ expandedRounds: next });
+    get().computeLayout();
+  },
+
   clear: () => {
     set({
       sessionKey: null,
       entries: [],
+      rounds: [],
       graphNodes: [],
       graphEdges: [],
       selectedNodeId: null,
+      expandedRounds: new Set(),
       loading: false,
       error: null,
     });


### PR DESCRIPTION
## Per Issue #4 requirements
- **Rounds**: Messages grouped into user→assistant interaction rounds (tool calls merged)
- **Tool call bones**: Collapsed by default, toggle ▶/▼ to expand vertically (fishbone ribs)
- **Colors**: Blue=normal, Orange=tool_call, Purple=subagent
- **Node badges**: 🔧×N tool count, 🧬 subagent indicator
- **Hover tooltip**: User prompt + assistant response preview

68/68 tests (16 fishbone + 8 rounds + existing)