### PR TITLE
fix: NaN tokens, filtered session count (#13-#16)

### DIFF
--- a/src/components/SessionList/SessionList.tsx
+++ b/src/components/SessionList/SessionList.tsx
@@ -49,7 +49,7 @@ export function SessionList() {
           Sessions
           {sessions.size > 0 && (
             <span className="ml-1.5 text-gray-500 normal-case tracking-normal">
-              ({sessions.size})
+              ({filteredTree.length !== sessions.size ? `${filteredTree.length}/` : ''}{sessions.size})
             </span>
           )}
         </h2>

--- a/src/store/sessions.test.ts
+++ b/src/store/sessions.test.ts
@@ -224,6 +224,11 @@ describe('formatTokens', () => {
     expect(formatTokens(1_000_000)).toBe('1.0M');
     expect(formatTokens(2_500_000)).toBe('2.5M');
   });
+
+  it('should return dash for undefined or NaN', () => {
+    expect(formatTokens(undefined)).toBe('—');
+    expect(formatTokens(NaN)).toBe('—');
+  });
 });
 
 // ── shortenModel ─────────────────────────────────────────────────────

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -91,7 +91,8 @@ export function formatRelativeTime(dateInput: string | number): string {
 
 // ── Helper: Format token count ───────────────────────────────────────
 
-export function formatTokens(tokens: number): string {
+export function formatTokens(tokens: number | undefined): string {
+  if (tokens == null || Number.isNaN(tokens)) return '—';
   if (tokens < 1000) return `${tokens}`;
   if (tokens < 1_000_000) return `${(tokens / 1000).toFixed(1)}k`;
   return `${(tokens / 1_000_000).toFixed(1)}M`;


### PR DESCRIPTION
Fixes #13 #14 #15 #16
- CSP already correct in source; stale dist not tracked
- formatTokens() handles undefined/NaN gracefully
- Session header shows filtered/total count
- 69/69 tests pass