### PR TITLE
fix: sidebar collapse, disconnect button, markdown strip (#17-#19)

### DIFF
--- a/src/components/SessionList/SessionList.tsx
+++ b/src/components/SessionList/SessionList.tsx
@@ -6,6 +6,7 @@ import { SessionTreeItem } from './SessionTreeItem';
 
 export function SessionList() {
   const status = useConnectionStore((s) => s.status);
+  const disconnect = useConnectionStore((s) => s.disconnect);
   const fetchSessions = useSessionStore((s) => s.fetchSessions);
   const getFilteredTree = useSessionStore((s) => s.getFilteredTree);
   const loading = useSessionStore((s) => s.loading);
@@ -13,6 +14,7 @@ export function SessionList() {
   const filterQuery = useSessionStore((s) => s.filterQuery);
   const sessions = useSessionStore((s) => s.sessions);
   const sessionTree = useSessionStore((s) => s.sessionTree);
+  const clearSessions = useSessionStore((s) => s.clearSessions);
   const [collapsed, setCollapsed] = useState(false);
 
   // Fetch sessions when connected
@@ -25,120 +27,143 @@ export function SessionList() {
   // Derive filtered tree (depends on sessionTree, filterQuery, sessions)
   const filteredTree = getFilteredTree();
 
-  if (collapsed) {
-    return (
-      <aside className="w-10 bg-surface-secondary border-r border-surface-tertiary flex flex-col items-center pt-3 shrink-0">
-        <button
-          onClick={() => setCollapsed(false)}
-          className="text-gray-500 hover:text-gray-300 transition-colors p-1"
-          title="Expand sidebar"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
-          </svg>
-        </button>
-      </aside>
-    );
-  }
+  const handleDisconnect = () => {
+    clearSessions();
+    disconnect();
+  };
+
+  // Bug #17 fix: Instead of conditionally rendering two different component
+  // trees (which unmounts SessionTreeItem children and can trigger effects
+  // that clear selectedSessionKey), we always render the same component tree
+  // and use CSS to toggle between collapsed and expanded visual states.
+  // This preserves all React state and prevents activeSessionKey from being cleared.
 
   return (
-    <aside className="w-72 bg-surface-secondary border-r border-surface-tertiary flex flex-col shrink-0">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2.5 border-b border-surface-tertiary">
-        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
-          Sessions
-          {sessions.size > 0 && (
-            <span className="ml-1.5 text-gray-500 normal-case tracking-normal">
-              ({filteredTree.length !== sessions.size ? `${filteredTree.length}/` : ''}{sessions.size})
-            </span>
-          )}
-        </h2>
-        <div className="flex items-center gap-1">
-          {/* Refresh button */}
+    <aside className={`${collapsed ? 'w-10' : 'w-72'} bg-surface-secondary border-r border-surface-tertiary flex flex-col shrink-0 transition-[width] duration-150`}>
+      {/* Collapsed: expand button */}
+      {collapsed && (
+        <div className="flex flex-col items-center pt-3">
           <button
-            onClick={() => fetchSessions()}
-            disabled={loading}
-            className="text-gray-500 hover:text-gray-300 transition-colors p-1 disabled:opacity-50"
-            title="Refresh sessions"
-          >
-            <svg
-              className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-          </button>
-          {/* Collapse button */}
-          <button
-            onClick={() => setCollapsed(true)}
+            onClick={() => setCollapsed(false)}
             className="text-gray-500 hover:text-gray-300 transition-colors p-1"
-            title="Collapse sidebar"
+            title="Expand sidebar"
           >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M11 19l-7-7 7-7M18 19l-7-7 7-7" />
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
             </svg>
           </button>
         </div>
-      </div>
+      )}
 
-      {/* Filter */}
-      <div className="pt-2">
-        <SessionFilter />
-      </div>
-
-      {/* Session tree */}
-      <div className="flex-1 overflow-y-auto py-1">
-        {loading && sessions.size === 0 ? (
-          <div className="px-3 py-8 text-center">
-            <svg
-              className="w-5 h-5 animate-spin text-gray-500 mx-auto mb-2"
-              fill="none"
-              viewBox="0 0 24 24"
+      {/* Expanded: full sidebar content */}
+      <div className={collapsed ? 'hidden' : 'flex flex-col flex-1 min-h-0'}>
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2.5 border-b border-surface-tertiary">
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+            Sessions
+            {sessions.size > 0 && (
+              <span className="ml-1.5 text-gray-500 normal-case tracking-normal">
+                ({filteredTree.length !== sessions.size ? `${filteredTree.length}/` : ''}{sessions.size})
+              </span>
+            )}
+          </h2>
+          <div className="flex items-center gap-1">
+            {/* Disconnect button */}
+            <button
+              onClick={handleDisconnect}
+              className="text-gray-500 hover:text-red-400 transition-colors p-1"
+              title="Disconnect"
             >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-              />
-            </svg>
-            <p className="text-xs text-gray-500">Loading sessions…</p>
-          </div>
-        ) : error ? (
-          <div className="px-3 py-4">
-            <p className="text-xs text-status-error">{error}</p>
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+            </button>
+            {/* Refresh button */}
             <button
               onClick={() => fetchSessions()}
-              className="text-xs text-accent hover:text-accent-hover mt-1"
+              disabled={loading}
+              className="text-gray-500 hover:text-gray-300 transition-colors p-1 disabled:opacity-50"
+              title="Refresh sessions"
             >
-              Retry
+              <svg
+                className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
+            </button>
+            {/* Collapse button */}
+            <button
+              onClick={() => setCollapsed(true)}
+              className="text-gray-500 hover:text-gray-300 transition-colors p-1"
+              title="Collapse sidebar"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M11 19l-7-7 7-7M18 19l-7-7 7-7" />
+              </svg>
             </button>
           </div>
-        ) : filteredTree.length === 0 ? (
-          <div className="px-3 py-8 text-center">
-            <p className="text-xs text-gray-500">
-              {filterQuery ? 'No sessions match filter.' : 'No sessions found.'}
-            </p>
-          </div>
-        ) : (
-          filteredTree.map((node) => (
-            <SessionTreeItem key={node.session.key} node={node} depth={0} />
-          ))
-        )}
+        </div>
+
+        {/* Filter */}
+        <div className="pt-2">
+          <SessionFilter />
+        </div>
+
+        {/* Session tree */}
+        <div className="flex-1 overflow-y-auto py-1">
+          {loading && sessions.size === 0 ? (
+            <div className="px-3 py-8 text-center">
+              <svg
+                className="w-5 h-5 animate-spin text-gray-500 mx-auto mb-2"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              <p className="text-xs text-gray-500">Loading sessions…</p>
+            </div>
+          ) : error ? (
+            <div className="px-3 py-4">
+              <p className="text-xs text-status-error">{error}</p>
+              <button
+                onClick={() => fetchSessions()}
+                className="text-xs text-accent hover:text-accent-hover mt-1"
+              >
+                Retry
+              </button>
+            </div>
+          ) : filteredTree.length === 0 ? (
+            <div className="px-3 py-8 text-center">
+              <p className="text-xs text-gray-500">
+                {filterQuery ? 'No sessions match filter.' : 'No sessions found.'}
+              </p>
+            </div>
+          ) : (
+            filteredTree.map((node) => (
+              <SessionTreeItem key={node.session.key} node={node} depth={0} />
+            ))
+          )}
+        </div>
       </div>
     </aside>
   );

--- a/src/layout/fishbone.ts
+++ b/src/layout/fishbone.ts
@@ -66,13 +66,28 @@ export interface SessionNodeData {
 
 // ── Preview helpers ──────────────────────────────────────────────────
 
+/**
+ * Strip common markdown syntax from text for clean display in graph nodes.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, '')         // code blocks (must be before inline code)
+    .replace(/\*\*(.*?)\*\*/g, '$1')        // bold
+    .replace(/\*(.*?)\*/g, '$1')            // italic
+    .replace(/`(.*?)`/g, '$1')              // inline code
+    .replace(/^#+\s/gm, '')                 // headers
+    .replace(/^[-*]\s/gm, '')               // list items
+    .replace(/\[(.*?)\]\(.*?\)/g, '$1')     // links
+    .trim();
+}
+
 function extractTextPreview(entry: import('@/gateway/types').TranscriptEntry | undefined, maxLen = 200): string {
   if (!entry?.message) return '';
   const content = entry.message.content;
-  if (typeof content === 'string') return content.slice(0, maxLen);
+  if (typeof content === 'string') return stripMarkdown(content.slice(0, maxLen));
   if (Array.isArray(content)) {
     const textBlock = content.find((b: any) => b.type === 'text' && b.text);
-    if (textBlock?.text) return (textBlock.text as string).slice(0, maxLen);
+    if (textBlock?.text) return stripMarkdown((textBlock.text as string).slice(0, maxLen));
   }
   return '';
 }

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -127,6 +127,8 @@ interface SessionStore {
   setFilterQuery: (query: string) => void;
   toggleExpanded: (key: string) => void;
   getFilteredTree: () => TreeNode[];
+  /** Clear all sessions and reset state (used on disconnect). */
+  clearSessions: () => void;
 }
 
 export const useSessionStore = create<SessionStore>((set, get) => ({
@@ -225,5 +227,16 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         }));
 
     return filterTree(sessionTree);
+  },
+
+  clearSessions: () => {
+    set({
+      sessions: new Map(),
+      sessionTree: [],
+      activeSessionKey: null,
+      filterQuery: '',
+      loading: false,
+      error: null,
+    });
   },
 }));


### PR DESCRIPTION
Fixes #17 #18 #19
- Sidebar collapse uses CSS toggle instead of conditional unmount (preserves selection)
- Disconnect button in sidebar header
- stripMarkdown() for node labels
- 69/69 tests pass