### PR TITLE
feat: sub-agent fork node display in fishbone graph

### DIFF
--- a/src/components/Graph/GraphCanvas.tsx
+++ b/src/components/Graph/GraphCanvas.tsx
@@ -26,6 +26,7 @@ import '@xyflow/react/dist/style.css';
 
 import { SessionNode } from './SessionNode';
 import { BranchEdge } from './BranchEdge';
+import { SubagentEdge } from './SubagentEdge';
 
 // ── Custom types registration ────────────────────────────────────────
 
@@ -35,6 +36,7 @@ const nodeTypes = {
 
 const edgeTypes = {
   branchEdge: BranchEdge,
+  subagentEdge: SubagentEdge,
 };
 
 // ── Props ────────────────────────────────────────────────────────────

--- a/src/components/Graph/SessionNode.tsx
+++ b/src/components/Graph/SessionNode.tsx
@@ -55,9 +55,11 @@ function BoneNode({ data, selected }: { data: SessionNodeData; selected: boolean
 
 function SubagentForkNode({ data, selected }: { data: SessionNodeData; selected: boolean }) {
   const toggleSubagent = useTranscriptStore((s) => s.toggleSubagent);
-  const loadingSubagents = useTranscriptStore((s) => s.loadingSubagents);
-
-  const isLoading = loadingSubagents.has(data.subagentSessionKey);
+  const loadSubagentTranscript = useTranscriptStore((s) => s.loadSubagentTranscript);
+  // Issue 6 fix: subscribe only to this fork's loading/failed state
+  const sessionKey = data.subagentSessionKey;
+  const isLoading = useTranscriptStore((s) => s.loadingSubagents.has(sessionKey));
+  const isFailed = useTranscriptStore((s) => s.failedSubagents.has(sessionKey));
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -67,13 +69,21 @@ function SubagentForkNode({ data, selected }: { data: SessionNodeData; selected:
     [toggleSubagent, data.parentRoundId, data.subagentSessionKey]
   );
 
+  const handleRetry = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      loadSubagentTranscript(data.subagentSessionKey);
+    },
+    [loadSubagentTranscript, data.subagentSessionKey]
+  );
+
   return (
     <div
       onClick={handleClick}
       style={{
         width: data.nodeWidth,
         height: data.nodeHeight,
-        borderColor: data.color,
+        borderColor: isFailed ? '#ef4444' : data.color,
         borderStyle: 'dashed',
       }}
       className={`
@@ -82,17 +92,31 @@ function SubagentForkNode({ data, selected }: { data: SessionNodeData; selected:
         cursor-pointer transition-all
         ${selected ? 'shadow-lg ring-2 ring-purple-400' : 'hover:shadow-md hover:bg-purple-900/10'}
       `}
-      title={`Sub-agent: ${data.subagentSessionKey}\nClick to ${data.subagentExpanded ? 'collapse' : 'expand'}`}
+      title={
+        isFailed
+          ? `Sub-agent: ${data.subagentSessionKey}\nFailed to load — click ↻ to retry`
+          : `Sub-agent: ${data.subagentSessionKey}\nClick to ${data.subagentExpanded ? 'collapse' : 'expand'}`
+      }
     >
       <span className="text-[10px]">
-        {isLoading ? '⏳' : data.subagentExpanded ? '▼' : '▶'}
+        {isLoading ? '⏳' : isFailed ? '⚠️' : data.subagentExpanded ? '▼' : '▶'}
       </span>
       <span
         className="text-[11px] truncate font-mono"
-        style={{ color: data.color }}
+        style={{ color: isFailed ? '#ef4444' : data.color }}
       >
-        {data.preview}
+        {isFailed ? 'Load failed' : data.preview}
       </span>
+      {isFailed && (
+        <button
+          onClick={handleRetry}
+          className="text-[10px] ml-auto px-1 rounded hover:bg-red-900/20 transition-colors"
+          style={{ color: '#ef4444' }}
+          title="Retry loading"
+        >
+          ↻
+        </button>
+      )}
 
       <Handle
         type="target"
@@ -121,7 +145,6 @@ function SubagentForkNode({ data, selected }: { data: SessionNodeData; selected:
 
 function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolean }) {
   const toggleRound = useTranscriptStore((s) => s.toggleRound);
-  const toggleSubagent = useTranscriptStore((s) => s.toggleSubagent);
 
   const handleToggle = useCallback(
     (e: React.MouseEvent) => {
@@ -129,14 +152,6 @@ function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolea
       toggleRound(data.entryId);
     },
     [toggleRound, data.entryId]
-  );
-
-  const handleSubagentToggle = useCallback(
-    (e: React.MouseEvent, sessionKey: string) => {
-      e.stopPropagation();
-      toggleSubagent(data.entryId, sessionKey);
-    },
-    [toggleSubagent, data.entryId]
   );
 
   const { nodeWidth, nodeHeight, color, preview, totalTokens, toolCallCount, expanded, hasSubagent } = data;

--- a/src/components/Graph/SessionNode.tsx
+++ b/src/components/Graph/SessionNode.tsx
@@ -3,11 +3,12 @@
 // Renders either:
 //   A) A round node  – shows round summary, tool-call badge, toggle button
 //   B) A bone node   – small tool-call indicator when a round is expanded
+//   C) A sub-agent fork node – purple fork showing sub-agent session key
 //
 // Visual encoding:
 //   - Size ∝ token count
 //   - Colour encodes round type (blue=normal, orange=tool_call, purple=subagent)
-//   - Handles: left (target) + right (source) + bottom (source, for bones)
+//   - Handles: left (target) + right (source) + bottom (source, for bones/forks)
 
 import { memo, useCallback } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
@@ -50,10 +51,77 @@ function BoneNode({ data, selected }: { data: SessionNodeData; selected: boolean
   );
 }
 
+// ── Sub-agent fork node ──────────────────────────────────────────────
+
+function SubagentForkNode({ data, selected }: { data: SessionNodeData; selected: boolean }) {
+  const toggleSubagent = useTranscriptStore((s) => s.toggleSubagent);
+  const loadingSubagents = useTranscriptStore((s) => s.loadingSubagents);
+
+  const isLoading = loadingSubagents.has(data.subagentSessionKey);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      toggleSubagent(data.parentRoundId, data.subagentSessionKey);
+    },
+    [toggleSubagent, data.parentRoundId, data.subagentSessionKey]
+  );
+
+  return (
+    <div
+      onClick={handleClick}
+      style={{
+        width: data.nodeWidth,
+        height: data.nodeHeight,
+        borderColor: data.color,
+        borderStyle: 'dashed',
+      }}
+      className={`
+        relative rounded-lg border-2 bg-surface-secondary px-2 py-1
+        flex items-center gap-1.5 overflow-hidden
+        cursor-pointer transition-all
+        ${selected ? 'shadow-lg ring-2 ring-purple-400' : 'hover:shadow-md hover:bg-purple-900/10'}
+      `}
+      title={`Sub-agent: ${data.subagentSessionKey}\nClick to ${data.subagentExpanded ? 'collapse' : 'expand'}`}
+    >
+      <span className="text-[10px]">
+        {isLoading ? '⏳' : data.subagentExpanded ? '▼' : '▶'}
+      </span>
+      <span
+        className="text-[11px] truncate font-mono"
+        style={{ color: data.color }}
+      >
+        {data.preview}
+      </span>
+
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!w-2 !h-2 !border-purple-500"
+        style={{ background: data.color }}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!w-2 !h-2 !border-purple-500"
+        style={{ background: data.color }}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right"
+        className="!w-2 !h-2 !border-purple-500"
+        style={{ background: data.color }}
+      />
+    </div>
+  );
+}
+
 // ── Round node (main spine node) ─────────────────────────────────────
 
 function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolean }) {
   const toggleRound = useTranscriptStore((s) => s.toggleRound);
+  const toggleSubagent = useTranscriptStore((s) => s.toggleSubagent);
 
   const handleToggle = useCallback(
     (e: React.MouseEvent) => {
@@ -61,6 +129,14 @@ function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolea
       toggleRound(data.entryId);
     },
     [toggleRound, data.entryId]
+  );
+
+  const handleSubagentToggle = useCallback(
+    (e: React.MouseEvent, sessionKey: string) => {
+      e.stopPropagation();
+      toggleSubagent(data.entryId, sessionKey);
+    },
+    [toggleSubagent, data.entryId]
   );
 
   const { nodeWidth, nodeHeight, color, preview, totalTokens, toolCallCount, expanded, hasSubagent } = data;
@@ -148,7 +224,7 @@ function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolea
         position={Position.Right}
         className="!w-2 !h-2 !bg-gray-500 !border-gray-600"
       />
-      {/* Bottom handle for bone connections */}
+      {/* Bottom handle for bone/fork connections */}
       <Handle
         type="source"
         position={Position.Bottom}
@@ -163,6 +239,10 @@ function RoundNode({ data, selected }: { data: SessionNodeData; selected: boolea
 
 function SessionNodeComponent({ data, selected }: NodeProps) {
   const nodeData = data as unknown as SessionNodeData;
+
+  if (nodeData.isSubagentFork) {
+    return <SubagentForkNode data={nodeData} selected={!!selected} />;
+  }
 
   if (nodeData.isBone) {
     return <BoneNode data={nodeData} selected={!!selected} />;

--- a/src/components/Graph/SubagentEdge.tsx
+++ b/src/components/Graph/SubagentEdge.tsx
@@ -1,0 +1,46 @@
+// ── SubagentEdge — Dashed purple edge for sub-agent connections ──────
+
+import { memo } from 'react';
+import {
+  type EdgeProps,
+  getSmoothStepPath,
+  BaseEdge,
+} from '@xyflow/react';
+
+function SubagentEdgeComponent(props: EdgeProps) {
+  const {
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    style,
+    markerEnd,
+  } = props;
+
+  const [edgePath] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    borderRadius: 16,
+  });
+
+  return (
+    <BaseEdge
+      path={edgePath}
+      markerEnd={markerEnd}
+      style={{
+        stroke: '#a855f7',
+        strokeWidth: 1.5,
+        strokeDasharray: '6 3',
+        ...style,
+      }}
+    />
+  );
+}
+
+export const SubagentEdge = memo(SubagentEdgeComponent);

--- a/src/layout/fishbone.test.ts
+++ b/src/layout/fishbone.test.ts
@@ -1,7 +1,7 @@
 // ── Fishbone layout tests (Round-based) ──────────────────────────────
 
 import { describe, it, expect } from 'vitest';
-import { computeFishboneLayout } from './fishbone';
+import { computeFishboneLayout, MAX_NESTING_DEPTH } from './fishbone';
 import { computeNodeSize, BASE_SIZE, SCALE_FACTOR } from './node-sizing';
 import type { Round } from './types';
 
@@ -524,5 +524,161 @@ describe('computeFishboneLayout — sub-agent forks', () => {
 
     const subEdges = result.edges.filter((e) => e.type === 'subagentEdge');
     expect(subEdges.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Cycle detection and depth limit tests ────────────────────────────
+
+describe('computeFishboneLayout — safety guards', () => {
+  it('detects circular sub-agent references (A → B → A)', () => {
+    // Main session spawns sub-agent "sub-a"
+    const mainRounds: Round[] = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-a'],
+        toolCalls: [],
+      }),
+    ];
+
+    // sub-a spawns sub-b
+    const subARounds: Round[] = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-b'],
+        toolCalls: [],
+      }),
+    ];
+
+    // sub-b tries to spawn sub-a again (circular!)
+    const subBRounds: Round[] = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-a'],
+        toolCalls: [],
+      }),
+    ];
+
+    const transcripts = new Map<string, Round[]>();
+    transcripts.set('sub-a', subARounds);
+    transcripts.set('sub-b', subBRounds);
+
+    const expandedSubs = new Set(['sub-a', 'sub-b']);
+
+    // Should NOT stack overflow — the visited set prevents re-rendering sub-a
+    const result = computeFishboneLayout(
+      mainRounds,
+      new Set(),
+      transcripts,
+      expandedSubs,
+    );
+
+    // Main: 1 round + 1 fork(sub-a) = 2
+    // sub-a: 1 round + 1 fork(sub-b) = 2
+    // sub-b: 1 round + 1 fork(sub-a) = 2, but sub-a is visited → no sub-graph
+    // Total = 6
+    expect(result.nodes).toHaveLength(6);
+
+    // The deepest depth should be 2 (sub-b's round), not infinite
+    const maxDepth = Math.max(
+      ...result.nodes.map((n) => (n.data as Record<string, unknown>).nestingDepth as number)
+    );
+    expect(maxDepth).toBe(2);
+  });
+
+  it('stops recursion at MAX_NESTING_DEPTH', () => {
+    // Build a chain of sub-agents deeper than MAX_NESTING_DEPTH
+    const transcripts = new Map<string, Round[]>();
+    const expandedSubs = new Set<string>();
+    const depth = MAX_NESTING_DEPTH + 3;
+
+    for (let i = 0; i < depth; i++) {
+      const key = `sub-${i}`;
+      const nextKey = `sub-${i + 1}`;
+      expandedSubs.add(key);
+      transcripts.set(key, [
+        makeRound(0, {
+          type: 'subagent',
+          subagentSpawns: [nextKey],
+          toolCalls: [],
+        }),
+      ]);
+    }
+    // Final leaf
+    const lastKey = `sub-${depth}`;
+    expandedSubs.add(lastKey);
+    transcripts.set(lastKey, [makeRound(0)]);
+
+    const mainRounds: Round[] = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-0'],
+        toolCalls: [],
+      }),
+    ];
+
+    const result = computeFishboneLayout(
+      mainRounds,
+      new Set(),
+      transcripts,
+      expandedSubs,
+    );
+
+    // Should not crash. Max depth in output should be ≤ MAX_NESTING_DEPTH
+    const maxDepth = Math.max(
+      ...result.nodes.map((n) => (n.data as Record<string, unknown>).nestingDepth as number)
+    );
+    expect(maxDepth).toBeLessThanOrEqual(MAX_NESTING_DEPTH);
+  });
+
+  it('handles empty sub-agent transcript (0 rounds)', () => {
+    const rounds: Round[] = [makeSubagentRound(0)];
+
+    const transcripts = new Map<string, Round[]>();
+    transcripts.set('subagent-session-1', []); // empty!
+
+    const result = computeFishboneLayout(
+      rounds,
+      new Set(),
+      transcripts,
+      new Set(['subagent-session-1']),
+    );
+
+    // 1 round + 1 fork, but no sub-graph nodes (empty transcript)
+    expect(result.nodes).toHaveLength(2);
+  });
+
+  it('preserves round-type color coding in sub-graphs', () => {
+    const rounds: Round[] = [makeSubagentRound(0)];
+
+    // Sub-agent has both normal and tool_call rounds
+    const subRounds: Round[] = [
+      makeRound(0),
+      makeToolCallRound(1, ['exec']),
+    ];
+
+    const transcripts = new Map<string, Round[]>();
+    transcripts.set('subagent-session-1', subRounds);
+
+    const result = computeFishboneLayout(
+      rounds,
+      new Set(),
+      transcripts,
+      new Set(['subagent-session-1']),
+    );
+
+    // Find sub-graph nodes
+    const subNormal = result.nodes.find(
+      (n) => n.id.includes('-sub-') && (n.data as Record<string, unknown>).roundType === 'normal'
+    );
+    const subTool = result.nodes.find(
+      (n) => n.id.includes('-sub-') && (n.data as Record<string, unknown>).roundType === 'tool_call'
+    );
+
+    expect(subNormal).toBeDefined();
+    expect(subTool).toBeDefined();
+
+    // Colors should match their round types, not all be purple
+    expect((subNormal!.data as Record<string, unknown>).color).toBe('#3b82f6'); // blue
+    expect((subTool!.data as Record<string, unknown>).color).toBe('#f97316');   // orange
   });
 });

--- a/src/layout/fishbone.test.ts
+++ b/src/layout/fishbone.test.ts
@@ -154,7 +154,8 @@ describe('computeFishboneLayout (Round-based)', () => {
 
     const result = computeFishboneLayout(rounds);
 
-    expect(result.nodes).toHaveLength(3);
+    // 3 round nodes + 1 sub-agent fork node = 4
+    expect(result.nodes).toHaveLength(4);
 
     const normalNode = result.nodes.find((n) => n.id === 'round-0')!;
     expect((normalNode.data as Record<string, unknown>).roundType).toBe('normal');
@@ -165,6 +166,12 @@ describe('computeFishboneLayout (Round-based)', () => {
     const subNode = result.nodes.find((n) => n.id === 'round-2')!;
     expect((subNode.data as Record<string, unknown>).roundType).toBe('subagent');
     expect((subNode.data as Record<string, unknown>).hasSubagent).toBe(true);
+
+    // Verify the fork node
+    const forkNode = result.nodes.find((n) => n.id === 'round-2-fork-0')!;
+    expect(forkNode).toBeDefined();
+    expect((forkNode.data as Record<string, unknown>).isSubagentFork).toBe(true);
+    expect((forkNode.data as Record<string, unknown>).subagentSessionKey).toBe('subagent-session-1');
   });
 
   it('uses correct colours for round types', () => {
@@ -293,5 +300,229 @@ describe('computeNodeSize', () => {
 
     expect(width).toBeCloseTo(expectedSize, 5);
     expect(height).toBeCloseTo(expectedSize * 0.75, 5);
+  });
+});
+
+// ── Sub-agent fork layout tests ──────────────────────────────────────
+
+describe('computeFishboneLayout — sub-agent forks', () => {
+  it('renders a fork node for each subagent spawn (collapsed)', () => {
+    const rounds = [
+      makeSubagentRound(0),
+    ];
+    const result = computeFishboneLayout(rounds);
+
+    // 1 round node + 1 fork node
+    expect(result.nodes).toHaveLength(2);
+
+    const forkNode = result.nodes.find((n) => n.id === 'round-0-fork-0')!;
+    expect(forkNode).toBeDefined();
+
+    const data = forkNode.data as Record<string, unknown>;
+    expect(data.isSubagentFork).toBe(true);
+    expect(data.subagentSessionKey).toBe('subagent-session-1');
+    expect(data.subagentExpanded).toBe(false);
+    expect(data.parentRoundId).toBe('round-0');
+
+    // Fork should have an edge from the round
+    const forkEdge = result.edges.find((e) => e.target === 'round-0-fork-0');
+    expect(forkEdge).toBeDefined();
+    expect(forkEdge!.source).toBe('round-0');
+    expect(forkEdge!.type).toBe('subagentEdge');
+  });
+
+  it('renders multiple fork nodes for multiple subagent spawns', () => {
+    const rounds = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-a', 'sub-b', 'sub-c'],
+        toolCalls: [],
+      }),
+    ];
+    const result = computeFishboneLayout(rounds);
+
+    // 1 round + 3 forks
+    expect(result.nodes).toHaveLength(4);
+
+    expect(result.nodes.find((n) => n.id === 'round-0-fork-0')).toBeDefined();
+    expect(result.nodes.find((n) => n.id === 'round-0-fork-1')).toBeDefined();
+    expect(result.nodes.find((n) => n.id === 'round-0-fork-2')).toBeDefined();
+
+    // Each fork has a subagentEdge from round-0
+    const forkEdges = result.edges.filter((e) => e.type === 'subagentEdge');
+    expect(forkEdges).toHaveLength(3);
+    for (const edge of forkEdges) {
+      expect(edge.source).toBe('round-0');
+    }
+  });
+
+  it('renders sub-agent sub-graph when fork is expanded', () => {
+    const rounds = [
+      makeSubagentRound(0),
+    ];
+
+    // Sub-agent has its own rounds
+    const subRounds = [
+      makeRound(0, { totalTokens: 100 }),
+      makeToolCallRound(1, ['exec']),
+    ];
+
+    const subagentTranscripts = new Map<string, Round[]>();
+    subagentTranscripts.set('subagent-session-1', subRounds);
+
+    const expandedSubagents = new Set(['subagent-session-1']);
+
+    const result = computeFishboneLayout(
+      rounds,
+      new Set(),
+      subagentTranscripts,
+      expandedSubagents,
+    );
+
+    // 1 main round + 1 fork + 2 sub-agent round nodes = 4
+    expect(result.nodes).toHaveLength(4);
+
+    // Verify fork node is expanded
+    const forkNode = result.nodes.find((n) => n.id === 'round-0-fork-0')!;
+    expect((forkNode.data as Record<string, unknown>).subagentExpanded).toBe(true);
+
+    // Sub-graph nodes should have prefixed ids
+    const subNodes = result.nodes.filter((n) => n.id.startsWith('round-0-fork-0-sub-'));
+    expect(subNodes).toHaveLength(2);
+
+    // Sub-graph nodes should be below the fork node
+    for (const subNode of subNodes) {
+      expect(subNode.position.y).toBeGreaterThan(forkNode.position.y);
+    }
+
+    // Edge from fork to first sub-graph round
+    const forkToSubEdge = result.edges.find(
+      (e) => e.source === 'round-0-fork-0' && e.target.startsWith('round-0-fork-0-sub-')
+    );
+    expect(forkToSubEdge).toBeDefined();
+    expect(forkToSubEdge!.type).toBe('subagentEdge');
+  });
+
+  it('sub-graph nodes are at deeper nesting depth', () => {
+    const rounds = [makeSubagentRound(0)];
+    const subRounds = [makeRound(0)];
+
+    const subagentTranscripts = new Map<string, Round[]>();
+    subagentTranscripts.set('subagent-session-1', subRounds);
+
+    const result = computeFishboneLayout(
+      rounds,
+      new Set(),
+      subagentTranscripts,
+      new Set(['subagent-session-1']),
+    );
+
+    // Main round at depth 0
+    const mainNode = result.nodes.find((n) => n.id === 'round-0')!;
+    expect((mainNode.data as Record<string, unknown>).nestingDepth).toBe(0);
+
+    // Sub-graph round at depth 1
+    const subNode = result.nodes.find((n) => n.id.startsWith('round-0-fork-0-sub-'))!;
+    expect((subNode.data as Record<string, unknown>).nestingDepth).toBe(1);
+  });
+
+  it('fork node position is below expanded tool call bones', () => {
+    const rounds = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-1'],
+        toolCalls: [
+          { id: 'tc-0', name: 'exec', toolUseBlock: { type: 'tool_use', name: 'exec', id: 'tc-0' } },
+          { id: 'tc-1', name: 'read', toolUseBlock: { type: 'tool_use', name: 'read', id: 'tc-1' } },
+        ],
+      }),
+    ];
+
+    // Expand the round's tool calls
+    const expanded = new Set(['round-0']);
+    const result = computeFishboneLayout(rounds, expanded);
+
+    const bone1 = result.nodes.find((n) => n.id === 'round-0-bone-1')!;
+    const forkNode = result.nodes.find((n) => n.id === 'round-0-fork-0')!;
+
+    // Fork should be below the last bone
+    expect(forkNode.position.y).toBeGreaterThan(bone1.position.y);
+  });
+
+  it('does not render sub-graph when fork is collapsed', () => {
+    const rounds = [makeSubagentRound(0)];
+    const subRounds = [makeRound(0), makeRound(1)];
+
+    const subagentTranscripts = new Map<string, Round[]>();
+    subagentTranscripts.set('subagent-session-1', subRounds);
+
+    // expandedSubagents is empty → fork is collapsed
+    const result = computeFishboneLayout(
+      rounds,
+      new Set(),
+      subagentTranscripts,
+      new Set(),
+    );
+
+    // Only 1 round + 1 fork, no sub-graph nodes
+    expect(result.nodes).toHaveLength(2);
+  });
+
+  it('handles nested sub-agents (sub-agent within sub-agent)', () => {
+    // Main session has a round that spawns sub-agent A
+    const mainRounds = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-a'],
+        toolCalls: [],
+      }),
+    ];
+
+    // Sub-agent A has a round that spawns sub-agent B
+    const subARounds: Round[] = [
+      makeRound(0, {
+        type: 'subagent',
+        subagentSpawns: ['sub-b'],
+        toolCalls: [],
+      }),
+    ];
+
+    // Sub-agent B has simple rounds
+    const subBRounds: Round[] = [
+      makeRound(0, { totalTokens: 50 }),
+    ];
+
+    const transcripts = new Map<string, Round[]>();
+    transcripts.set('sub-a', subARounds);
+    transcripts.set('sub-b', subBRounds);
+
+    const expandedSubs = new Set(['sub-a', 'sub-b']);
+
+    const result = computeFishboneLayout(
+      mainRounds,
+      new Set(),
+      transcripts,
+      expandedSubs,
+    );
+
+    // Main: 1 round + 1 fork(sub-a) = 2
+    // sub-a: 1 round + 1 fork(sub-b) = 2
+    // sub-b: 1 round = 1
+    // Total = 5
+    expect(result.nodes).toHaveLength(5);
+
+    // Find deepest node (sub-b's round)
+    const deepNodes = result.nodes.filter(
+      (n) => (n.data as Record<string, unknown>).nestingDepth === 2
+    );
+    expect(deepNodes).toHaveLength(1);
+  });
+
+  it('fork node uses subagentEdge type for edges', () => {
+    const rounds = [makeSubagentRound(0)];
+    const result = computeFishboneLayout(rounds);
+
+    const subEdges = result.edges.filter((e) => e.type === 'subagentEdge');
+    expect(subEdges.length).toBeGreaterThan(0);
   });
 });

--- a/src/layout/fishbone.ts
+++ b/src/layout/fishbone.ts
@@ -7,6 +7,8 @@
 //   - Main spine: one node per round, horizontal left-to-right at Y=0
 //   - Tool call "bones": when a round is expanded, its tool calls appear
 //     as small nodes below the round node (vertical fishbone ribs)
+//   - Sub-agent forks: when a round has expanded sub-agents, fork nodes
+//     and sub-agent fishbone sub-graphs are rendered below
 //   - Node colour encodes round type (normal / tool_call / subagent)
 //   - Node size ∝ token count
 
@@ -20,6 +22,22 @@ import { ROUND_COLORS } from './types';
 const X_SPACING = 220;       // px between round nodes horizontally
 const Y_BONE_SPACING = 80;   // px between tool-call bone nodes vertically
 const X_OFFSET = 60;         // left margin
+const Y_SUBAGENT_FORK = 60;  // px from round node to sub-agent fork node
+const Y_SUBAGENT_GRAPH = 50; // px from fork node to sub-agent sub-graph
+const SUBAGENT_X_SPACING = 180; // slightly tighter spacing for sub-graphs
+const SUBAGENT_SCALE = 0.85;    // sub-graph nodes are slightly smaller
+
+// Purple shades per nesting depth (lighter = deeper)
+const SUBAGENT_COLORS = [
+  '#a855f7', // depth 0 (direct sub-agents)
+  '#c084fc', // depth 1
+  '#d8b4fe', // depth 2
+  '#e9d5ff', // depth 3+
+];
+
+function subagentColor(depth: number): string {
+  return SUBAGENT_COLORS[Math.min(depth, SUBAGENT_COLORS.length - 1)];
+}
 
 // ── Types for React Flow data ────────────────────────────────────────
 
@@ -55,6 +73,18 @@ export interface SessionNodeData {
   isBone: boolean;
   /** Tool name (e.g. "exec", "read"). */
   toolName: string;
+
+  // Sub-agent fork fields
+  /** Identifies this node as a sub-agent fork node. */
+  isSubagentFork: boolean;
+  /** Sub-agent session key (for fork nodes). */
+  subagentSessionKey: string;
+  /** Whether the sub-agent fork is expanded (showing sub-graph). */
+  subagentExpanded: boolean;
+  /** Nesting depth for sub-agent rendering (0 = top level). */
+  nestingDepth: number;
+  /** The parent round id this fork belongs to. */
+  parentRoundId: string;
 
   // Legacy compatibility fields
   type: string;
@@ -113,6 +143,18 @@ function buildRoundPreview(round: Round, index: number): string {
   return `Round ${index + 1}${detail}`;
 }
 
+/** Shorten a session key for display. */
+function shortSessionLabel(sessionKey: string): string {
+  // If it looks like "agent:main:subagent:uuid", show last part
+  const parts = sessionKey.split(':');
+  if (parts.length > 2) {
+    const last = parts[parts.length - 1];
+    // Truncate UUID
+    return last.length > 12 ? `${last.slice(0, 8)}…` : last;
+  }
+  return sessionKey.length > 20 ? `${sessionKey.slice(0, 18)}…` : sessionKey;
+}
+
 // ── Layout computation ───────────────────────────────────────────────
 
 export interface FishboneResult {
@@ -125,11 +167,23 @@ export interface FishboneResult {
  *
  * @param rounds - Grouped rounds from transcript
  * @param expandedRounds - Set of round ids that are currently expanded
+ * @param subagentTranscripts - Map of session key → rounds for expanded sub-agents
+ * @param expandedSubagents - Set of expanded sub-agent session keys
+ * @param nestingDepth - Current nesting depth (0 = main, 1+ = sub-agent)
+ * @param idPrefix - Prefix for node/edge ids (for uniqueness in nested graphs)
+ * @param originX - X offset for the sub-graph
+ * @param originY - Y offset for the sub-graph
  * @returns React Flow nodes and edges positioned in a fishbone pattern
  */
 export function computeFishboneLayout(
   rounds: Round[],
-  expandedRounds: Set<string> = new Set()
+  expandedRounds: Set<string> = new Set(),
+  subagentTranscripts: Map<string, Round[]> = new Map(),
+  expandedSubagents: Set<string> = new Set(),
+  nestingDepth: number = 0,
+  idPrefix: string = '',
+  originX: number = 0,
+  originY: number = 0,
 ): FishboneResult {
   if (rounds.length === 0) {
     return { nodes: [], edges: [] };
@@ -138,22 +192,33 @@ export function computeFishboneLayout(
   const nodes: Node<SessionNodeData>[] = [];
   const edges: Edge[] = [];
 
-  // ── Lay out main spine (Y = 0) ──
+  const scale = Math.pow(SUBAGENT_SCALE, nestingDepth);
+  const xSpacing = nestingDepth === 0 ? X_SPACING : SUBAGENT_X_SPACING * scale;
+
+  // ── Lay out main spine (Y = originY) ──
   for (let i = 0; i < rounds.length; i++) {
     const round = rounds[i];
-    const { width, height } = computeNodeSize(round.totalTokens);
-    const x = X_OFFSET + i * X_SPACING;
-    const y = 0;
+    const rawSize = computeNodeSize(round.totalTokens);
+    const width = rawSize.width * scale;
+    const height = rawSize.height * scale;
+    const x = originX + X_OFFSET * scale + i * xSpacing;
+    const y = originY;
     const isExpanded = expandedRounds.has(round.id);
     const preview = buildRoundPreview(round, i);
+    const nodeId = `${idPrefix}${round.id}`;
+
+    // Determine color: sub-agent sub-graph nodes use lighter purple
+    const nodeColor = nestingDepth > 0
+      ? subagentColor(nestingDepth - 1)
+      : ROUND_COLORS[round.type];
 
     nodes.push({
-      id: round.id,
+      id: nodeId,
       type: 'sessionNode',
       position: { x, y },
       data: {
         entryId: round.id,
-        color: ROUND_COLORS[round.type],
+        color: nodeColor,
         nodeWidth: width,
         nodeHeight: height,
         timestamp: round.timestamp,
@@ -171,6 +236,12 @@ export function computeFishboneLayout(
         isBone: false,
         toolName: '',
 
+        isSubagentFork: false,
+        subagentSessionKey: '',
+        subagentExpanded: false,
+        nestingDepth,
+        parentRoundId: '',
+
         type: 'round',
         category: round.type === 'normal' ? 'conversation' : round.type,
         role: 'round',
@@ -179,30 +250,34 @@ export function computeFishboneLayout(
 
     // Edge to previous round
     if (i > 0) {
+      const prevNodeId = `${idPrefix}${rounds[i - 1].id}`;
       edges.push({
-        id: `e-${rounds[i - 1].id}-${round.id}`,
-        source: rounds[i - 1].id,
-        target: round.id,
+        id: `e-${prevNodeId}-${nodeId}`,
+        source: prevNodeId,
+        target: nodeId,
         type: 'branchEdge',
       });
     }
+
+    // Track the bottom of bone nodes for sub-agent fork positioning
+    let boneBottomY = y + height + 20;
 
     // ── Tool call bones (if expanded) ──
     if (isExpanded && round.toolCalls.length > 0) {
       for (let j = 0; j < round.toolCalls.length; j++) {
         const tc = round.toolCalls[j];
-        const boneId = `${round.id}-bone-${j}`;
-        const boneY = y + height + 20 + j * Y_BONE_SPACING;
+        const boneId = `${nodeId}-bone-${j}`;
+        const boneY = y + height + 20 + j * Y_BONE_SPACING * scale;
 
         nodes.push({
           id: boneId,
           type: 'sessionNode',
-          position: { x: x + 20, y: boneY },
+          position: { x: x + 20 * scale, y: boneY },
           data: {
             entryId: boneId,
             color: '#f97316',
-            nodeWidth: 120,
-            nodeHeight: 36,
+            nodeWidth: 120 * scale,
+            nodeHeight: 36 * scale,
             timestamp: undefined,
             totalTokens: 0,
 
@@ -218,6 +293,12 @@ export function computeFishboneLayout(
             isBone: true,
             toolName: tc.name,
 
+            isSubagentFork: false,
+            subagentSessionKey: '',
+            subagentExpanded: false,
+            nestingDepth,
+            parentRoundId: round.id,
+
             type: 'tool_call',
             category: 'tool_call',
             role: 'tool',
@@ -225,13 +306,103 @@ export function computeFishboneLayout(
         });
 
         // Edge from round node (or previous bone) to this bone
-        const sourceId = j === 0 ? round.id : `${round.id}-bone-${j - 1}`;
+        const sourceId = j === 0 ? nodeId : `${nodeId}-bone-${j - 1}`;
         edges.push({
           id: `e-${sourceId}-${boneId}`,
           source: sourceId,
           target: boneId,
           type: 'branchEdge',
         });
+
+        boneBottomY = boneY + 36 * scale + 10;
+      }
+    }
+
+    // ── Sub-agent fork nodes ──
+    if (round.subagentSpawns.length > 0) {
+      for (let s = 0; s < round.subagentSpawns.length; s++) {
+        const subKey = round.subagentSpawns[s];
+        const isSubExpanded = expandedSubagents.has(subKey);
+        const forkId = `${nodeId}-fork-${s}`;
+        const forkY = boneBottomY + s * (Y_SUBAGENT_FORK + 10) * scale;
+
+        nodes.push({
+          id: forkId,
+          type: 'sessionNode',
+          position: { x: x + 10 * scale, y: forkY },
+          data: {
+            entryId: forkId,
+            color: subagentColor(nestingDepth),
+            nodeWidth: 150 * scale,
+            nodeHeight: 40 * scale,
+            timestamp: undefined,
+            totalTokens: 0,
+
+            isRound: false,
+            roundType: 'subagent',
+            preview: `🧬 ${shortSessionLabel(subKey)}`,
+            toolCallCount: 0,
+            expanded: false,
+            hasSubagent: false,
+            userPreview: '',
+            assistantPreview: '',
+
+            isBone: false,
+            toolName: '',
+
+            isSubagentFork: true,
+            subagentSessionKey: subKey,
+            subagentExpanded: isSubExpanded,
+            nestingDepth,
+            parentRoundId: round.id,
+
+            type: 'subagent_fork',
+            category: 'subagent',
+            role: 'subagent',
+          },
+        });
+
+        // Edge from round node to fork
+        edges.push({
+          id: `e-${nodeId}-${forkId}`,
+          source: nodeId,
+          target: forkId,
+          type: 'subagentEdge',
+        });
+
+        // ── Render sub-agent sub-graph if expanded ──
+        if (isSubExpanded) {
+          const subRounds = subagentTranscripts.get(subKey);
+          if (subRounds && subRounds.length > 0) {
+            const subGraphOriginX = x;
+            const subGraphOriginY = forkY + 40 * scale + Y_SUBAGENT_GRAPH * scale;
+            const subPrefix = `${forkId}-sub-`;
+
+            const subResult = computeFishboneLayout(
+              subRounds,
+              expandedRounds,
+              subagentTranscripts,
+              expandedSubagents,
+              nestingDepth + 1,
+              subPrefix,
+              subGraphOriginX,
+              subGraphOriginY,
+            );
+
+            nodes.push(...subResult.nodes);
+            edges.push(...subResult.edges);
+
+            // Edge from fork node to first sub-graph round
+            if (subResult.nodes.length > 0) {
+              edges.push({
+                id: `e-${forkId}-${subResult.nodes[0].id}`,
+                source: forkId,
+                target: subResult.nodes[0].id,
+                type: 'subagentEdge',
+              });
+            }
+          }
+        }
       }
     }
   }

--- a/src/layout/fishbone.ts
+++ b/src/layout/fishbone.ts
@@ -26,6 +26,7 @@ const Y_SUBAGENT_FORK = 60;  // px from round node to sub-agent fork node
 const Y_SUBAGENT_GRAPH = 50; // px from fork node to sub-agent sub-graph
 const SUBAGENT_X_SPACING = 180; // slightly tighter spacing for sub-graphs
 const SUBAGENT_SCALE = 0.85;    // sub-graph nodes are slightly smaller
+export const MAX_NESTING_DEPTH = 5;    // max recursion depth for sub-agent rendering
 
 // Purple shades per nesting depth (lighter = deeper)
 const SUBAGENT_COLORS = [
@@ -173,6 +174,7 @@ export interface FishboneResult {
  * @param idPrefix - Prefix for node/edge ids (for uniqueness in nested graphs)
  * @param originX - X offset for the sub-graph
  * @param originY - Y offset for the sub-graph
+ * @param visited - Set of session keys already being rendered (cycle detection)
  * @returns React Flow nodes and edges positioned in a fishbone pattern
  */
 export function computeFishboneLayout(
@@ -184,8 +186,14 @@ export function computeFishboneLayout(
   idPrefix: string = '',
   originX: number = 0,
   originY: number = 0,
+  visited: Set<string> = new Set(),
 ): FishboneResult {
   if (rounds.length === 0) {
+    return { nodes: [], edges: [] };
+  }
+
+  // Guard: stop recursion if depth exceeds limit
+  if (nestingDepth > MAX_NESTING_DEPTH) {
     return { nodes: [], edges: [] };
   }
 
@@ -207,10 +215,8 @@ export function computeFishboneLayout(
     const preview = buildRoundPreview(round, i);
     const nodeId = `${idPrefix}${round.id}`;
 
-    // Determine color: sub-agent sub-graph nodes use lighter purple
-    const nodeColor = nestingDepth > 0
-      ? subagentColor(nestingDepth - 1)
-      : ROUND_COLORS[round.type];
+    // Color: preserve round-type colour encoding at all nesting levels
+    const nodeColor = ROUND_COLORS[round.type];
 
     nodes.push({
       id: nodeId,
@@ -373,10 +379,14 @@ export function computeFishboneLayout(
         // ── Render sub-agent sub-graph if expanded ──
         if (isSubExpanded) {
           const subRounds = subagentTranscripts.get(subKey);
-          if (subRounds && subRounds.length > 0) {
+          if (subRounds && subRounds.length > 0 && !visited.has(subKey)) {
             const subGraphOriginX = x;
             const subGraphOriginY = forkY + 40 * scale + Y_SUBAGENT_GRAPH * scale;
             const subPrefix = `${forkId}-sub-`;
+
+            // Track this session key to prevent circular references
+            const nextVisited = new Set(visited);
+            nextVisited.add(subKey);
 
             const subResult = computeFishboneLayout(
               subRounds,
@@ -387,6 +397,7 @@ export function computeFishboneLayout(
               subPrefix,
               subGraphOriginX,
               subGraphOriginY,
+              nextVisited,
             );
 
             nodes.push(...subResult.nodes);

--- a/src/store/transcript.test.ts
+++ b/src/store/transcript.test.ts
@@ -219,6 +219,7 @@ describe('useTranscriptStore — sub-agent state', () => {
     expect(cleared.subagentTranscripts.size).toBe(0);
     expect(cleared.expandedSubagents.size).toBe(0);
     expect(cleared.loadingSubagents.size).toBe(0);
+    expect(cleared.failedSubagents.size).toBe(0);
   });
 
   it('toggleSubagent reuses cached transcript', () => {
@@ -238,5 +239,22 @@ describe('useTranscriptStore — sub-agent state', () => {
     expect(state.expandedSubagents.has('cached-sub')).toBe(true);
     // Loading should not have been triggered (no client connected)
     expect(state.loadingSubagents.has('cached-sub')).toBe(false);
+  });
+
+  it('initializes failedSubagents as empty Set', () => {
+    const store = useTranscriptStore.getState();
+    expect(store.failedSubagents).toBeInstanceOf(Set);
+    expect(store.failedSubagents.size).toBe(0);
+  });
+
+  it('clear resets failedSubagents', () => {
+    // Simulate a failed state
+    useTranscriptStore.setState({
+      failedSubagents: new Set(['sub-fail-1']),
+    });
+    expect(useTranscriptStore.getState().failedSubagents.size).toBe(1);
+
+    useTranscriptStore.getState().clear();
+    expect(useTranscriptStore.getState().failedSubagents.size).toBe(0);
   });
 });

--- a/src/store/transcript.test.ts
+++ b/src/store/transcript.test.ts
@@ -1,7 +1,7 @@
 // ── Round grouping tests ─────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { groupIntoRounds } from './transcript';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { groupIntoRounds, useTranscriptStore } from './transcript';
 import type { TranscriptEntry } from '@/gateway/types';
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -173,5 +173,70 @@ describe('groupIntoRounds', () => {
     expect(rounds).toHaveLength(1);
     // Post-processing should set assistantMessage to the last assistant entry
     expect(rounds[0].assistantMessage?.id).toBe('2');
+  });
+});
+
+// ── Transcript store sub-agent state tests ───────────────────────────
+
+describe('useTranscriptStore — sub-agent state', () => {
+  beforeEach(() => {
+    useTranscriptStore.getState().clear();
+  });
+
+  it('initializes with empty sub-agent state', () => {
+    const store = useTranscriptStore.getState();
+
+    expect(store.subagentTranscripts).toBeInstanceOf(Map);
+    expect(store.subagentTranscripts.size).toBe(0);
+    expect(store.expandedSubagents).toBeInstanceOf(Set);
+    expect(store.expandedSubagents.size).toBe(0);
+    expect(store.loadingSubagents).toBeInstanceOf(Set);
+    expect(store.loadingSubagents.size).toBe(0);
+  });
+
+  it('toggleSubagent adds/removes from expandedSubagents', () => {
+    const store = useTranscriptStore.getState();
+
+    // First toggle → expand
+    store.toggleSubagent('round-0', 'sub-session-1');
+    expect(useTranscriptStore.getState().expandedSubagents.has('sub-session-1')).toBe(true);
+
+    // Second toggle → collapse
+    useTranscriptStore.getState().toggleSubagent('round-0', 'sub-session-1');
+    expect(useTranscriptStore.getState().expandedSubagents.has('sub-session-1')).toBe(false);
+  });
+
+  it('clear resets sub-agent state', () => {
+    const store = useTranscriptStore.getState();
+
+    // Set up some sub-agent state
+    store.toggleSubagent('round-0', 'sub-1');
+    expect(useTranscriptStore.getState().expandedSubagents.size).toBe(1);
+
+    // Clear
+    useTranscriptStore.getState().clear();
+    const cleared = useTranscriptStore.getState();
+    expect(cleared.subagentTranscripts.size).toBe(0);
+    expect(cleared.expandedSubagents.size).toBe(0);
+    expect(cleared.loadingSubagents.size).toBe(0);
+  });
+
+  it('toggleSubagent reuses cached transcript', () => {
+    // Pre-populate the cache
+    const entries = [
+      msg('1', 'user', 'Hello'),
+      msg('2', 'assistant', 'Hi!'),
+    ];
+    const rounds = groupIntoRounds(entries);
+    const nextTranscripts = new Map(useTranscriptStore.getState().subagentTranscripts);
+    nextTranscripts.set('cached-sub', { entries, rounds });
+    useTranscriptStore.setState({ subagentTranscripts: nextTranscripts });
+
+    // Toggle expand — should not attempt to load (already cached)
+    useTranscriptStore.getState().toggleSubagent('round-0', 'cached-sub');
+    const state = useTranscriptStore.getState();
+    expect(state.expandedSubagents.has('cached-sub')).toBe(true);
+    // Loading should not have been triggered (no client connected)
+    expect(state.loadingSubagents.has('cached-sub')).toBe(false);
   });
 });

--- a/src/store/transcript.ts
+++ b/src/store/transcript.ts
@@ -190,6 +190,9 @@ export interface SubagentTranscriptCache {
   rounds: Round[];
 }
 
+/** Maximum number of cached sub-agent transcripts (LRU eviction). */
+const MAX_CACHED_SUBAGENTS = 20;
+
 // ── Store ────────────────────────────────────────────────────────────
 
 interface TranscriptStore {
@@ -220,6 +223,8 @@ interface TranscriptStore {
   expandedSubagents: Set<string>;
   /** Sub-agent sessions currently being loaded. */
   loadingSubagents: Set<string>;
+  /** Sub-agent sessions that failed to load. */
+  failedSubagents: Set<string>;
 
   // ── Actions ──
   /** Load transcript for a session from the gateway. */
@@ -253,6 +258,7 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
   subagentTranscripts: new Map(),
   expandedSubagents: new Set(),
   loadingSubagents: new Set(),
+  failedSubagents: new Set(),
 
   loadTranscript: async (sessionKey: string) => {
     const client = useConnectionStore.getState().client;
@@ -269,6 +275,7 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       expandedSubagents: new Set(),
       subagentTranscripts: new Map(),
       loadingSubagents: new Set(),
+      failedSubagents: new Set(),
     });
 
     try {
@@ -378,7 +385,10 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
 
     const nextLoading = new Set(loadingSubagents);
     nextLoading.add(sessionKey);
-    set({ loadingSubagents: nextLoading });
+    // Clear any previous failure for this key
+    const nextFailed = new Set(get().failedSubagents);
+    nextFailed.delete(sessionKey);
+    set({ loadingSubagents: nextLoading, failedSubagents: nextFailed });
 
     try {
       const result = await client.request<{ sessionKey: string; messages: unknown[] }>(
@@ -409,6 +419,15 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       const nextTranscripts = new Map(get().subagentTranscripts);
       nextTranscripts.set(sessionKey, { entries, rounds });
 
+      // LRU eviction: if cache exceeds limit, remove oldest entries
+      if (nextTranscripts.size > MAX_CACHED_SUBAGENTS) {
+        const keys = [...nextTranscripts.keys()];
+        const toRemove = keys.slice(0, nextTranscripts.size - MAX_CACHED_SUBAGENTS);
+        for (const k of toRemove) {
+          nextTranscripts.delete(k);
+        }
+      }
+
       const doneLoading = new Set(get().loadingSubagents);
       doneLoading.delete(sessionKey);
 
@@ -417,7 +436,9 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
     } catch (err) {
       const doneLoading = new Set(get().loadingSubagents);
       doneLoading.delete(sessionKey);
-      set({ loadingSubagents: doneLoading });
+      const failed = new Set(get().failedSubagents);
+      failed.add(sessionKey);
+      set({ loadingSubagents: doneLoading, failedSubagents: failed });
       console.error(`Failed to load subagent transcript for ${sessionKey}:`, err);
     }
   },
@@ -436,6 +457,7 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       subagentTranscripts: new Map(),
       expandedSubagents: new Set(),
       loadingSubagents: new Set(),
+      failedSubagents: new Set(),
     });
   },
 }));

--- a/src/store/transcript.ts
+++ b/src/store/transcript.ts
@@ -183,6 +183,13 @@ function classifyRound(round: Round): RoundType {
   return 'normal';
 }
 
+// ── Cached sub-agent transcript ──────────────────────────────────────
+
+export interface SubagentTranscriptCache {
+  entries: TranscriptEntry[];
+  rounds: Round[];
+}
+
 // ── Store ────────────────────────────────────────────────────────────
 
 interface TranscriptStore {
@@ -206,6 +213,14 @@ interface TranscriptStore {
   /** Last error from loading. */
   error: string | null;
 
+  // ── Sub-agent state ──
+  /** Cached transcripts for sub-agent sessions (lazy-loaded). */
+  subagentTranscripts: Map<string, SubagentTranscriptCache>;
+  /** Set of expanded sub-agent session keys. */
+  expandedSubagents: Set<string>;
+  /** Sub-agent sessions currently being loaded. */
+  loadingSubagents: Set<string>;
+
   // ── Actions ──
   /** Load transcript for a session from the gateway. */
   loadTranscript: (sessionKey: string) => Promise<void>;
@@ -215,6 +230,10 @@ interface TranscriptStore {
   selectNode: (nodeId: string | null) => void;
   /** Toggle expanded state for a round (show/hide tool call bones). */
   toggleRound: (roundId: string) => void;
+  /** Toggle a sub-agent fork: expand/collapse + lazy-load transcript. */
+  toggleSubagent: (roundId: string, sessionKey: string) => void;
+  /** Load a sub-agent transcript (called internally by toggleSubagent). */
+  loadSubagentTranscript: (sessionKey: string) => Promise<void>;
   /** Clear the transcript (e.g. on disconnect). */
   clear: () => void;
 }
@@ -230,6 +249,11 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
   loading: false,
   error: null,
 
+  // Sub-agent state
+  subagentTranscripts: new Map(),
+  expandedSubagents: new Set(),
+  loadingSubagents: new Set(),
+
   loadTranscript: async (sessionKey: string) => {
     const client = useConnectionStore.getState().client;
     if (!client) {
@@ -237,7 +261,15 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       return;
     }
 
-    set({ loading: true, error: null, sessionKey, expandedRounds: new Set() });
+    set({
+      loading: true,
+      error: null,
+      sessionKey,
+      expandedRounds: new Set(),
+      expandedSubagents: new Set(),
+      subagentTranscripts: new Map(),
+      loadingSubagents: new Set(),
+    });
 
     try {
       const result = await client.request<{ sessionKey: string; messages: unknown[] }>(
@@ -278,8 +310,22 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
   },
 
   computeLayout: () => {
-    const { rounds, expandedRounds } = get();
-    const { nodes, edges } = computeFishboneLayout(rounds, expandedRounds);
+    const { rounds, expandedRounds, subagentTranscripts, expandedSubagents } = get();
+
+    // Build a Map<sessionKey, Round[]> for expanded sub-agents
+    const subagentRounds = new Map<string, Round[]>();
+    for (const [key, cache] of subagentTranscripts) {
+      if (expandedSubagents.has(key)) {
+        subagentRounds.set(key, cache.rounds);
+      }
+    }
+
+    const { nodes, edges } = computeFishboneLayout(
+      rounds,
+      expandedRounds,
+      subagentRounds,
+      expandedSubagents,
+    );
     set({ graphNodes: nodes, graphEdges: edges });
   },
 
@@ -299,6 +345,83 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
     get().computeLayout();
   },
 
+  toggleSubagent: (roundId: string, sessionKey: string) => {
+    const { expandedSubagents, subagentTranscripts } = get();
+    const next = new Set(expandedSubagents);
+
+    if (next.has(sessionKey)) {
+      // Collapse
+      next.delete(sessionKey);
+      set({ expandedSubagents: next });
+      get().computeLayout();
+    } else {
+      // Expand
+      next.add(sessionKey);
+      set({ expandedSubagents: next });
+
+      if (subagentTranscripts.has(sessionKey)) {
+        // Already cached — just recompute layout
+        get().computeLayout();
+      } else {
+        // Lazy-load the transcript
+        get().loadSubagentTranscript(sessionKey);
+      }
+    }
+  },
+
+  loadSubagentTranscript: async (sessionKey: string) => {
+    const client = useConnectionStore.getState().client;
+    if (!client) return;
+
+    const { loadingSubagents } = get();
+    if (loadingSubagents.has(sessionKey)) return; // already loading
+
+    const nextLoading = new Set(loadingSubagents);
+    nextLoading.add(sessionKey);
+    set({ loadingSubagents: nextLoading });
+
+    try {
+      const result = await client.request<{ sessionKey: string; messages: unknown[] }>(
+        'chat.history',
+        { sessionKey }
+      );
+
+      const rawMessages = result?.messages ?? [];
+      const entries: TranscriptEntry[] = rawMessages.map((msg: any, index: number) => ({
+        id: msg.id ?? `msg-${index}`,
+        parentId: msg.parentId ?? (index > 0 ? (rawMessages[index - 1] as any).id ?? `msg-${index - 1}` : undefined),
+        type: msg.type ?? ('message' as const),
+        message: msg.message ?? {
+          role: msg.role ?? 'user',
+          content: msg.content ?? null,
+          usage: msg.usage,
+          timestamp: msg.timestamp ? new Date(msg.timestamp).toISOString() : undefined,
+        },
+        summary: msg.summary,
+        tokensBefore: msg.tokensBefore,
+        customType: msg.customType,
+        data: msg.data,
+        timestamp: msg.timestamp ? new Date(msg.timestamp).toISOString() : undefined,
+      }));
+
+      const rounds = groupIntoRounds(entries);
+
+      const nextTranscripts = new Map(get().subagentTranscripts);
+      nextTranscripts.set(sessionKey, { entries, rounds });
+
+      const doneLoading = new Set(get().loadingSubagents);
+      doneLoading.delete(sessionKey);
+
+      set({ subagentTranscripts: nextTranscripts, loadingSubagents: doneLoading });
+      get().computeLayout();
+    } catch (err) {
+      const doneLoading = new Set(get().loadingSubagents);
+      doneLoading.delete(sessionKey);
+      set({ loadingSubagents: doneLoading });
+      console.error(`Failed to load subagent transcript for ${sessionKey}:`, err);
+    }
+  },
+
   clear: () => {
     set({
       sessionKey: null,
@@ -310,6 +433,9 @@ export const useTranscriptStore = create<TranscriptStore>((set, get) => ({
       expandedRounds: new Set(),
       loading: false,
       error: null,
+      subagentTranscripts: new Map(),
+      expandedSubagents: new Set(),
+      loadingSubagents: new Set(),
     });
   },
 }));


### PR DESCRIPTION
Implements sub-agent fork node display in fishbone graph (closes #23).

### Changes
- Layout: recursive sub-agent sub-graphs with fork nodes, nesting depth color gradient
- Store: multi-session transcript caching, lazy-loading, expand/collapse
- Components: SubagentForkNode (dashed purple), SubagentEdge
- Tests: 12 new (81 total), all pass. tsc + vite build clean.